### PR TITLE
fix:direct debt repayment fix

### DIFF
--- a/contracts/core/interfaces/IAssetHandler.sol
+++ b/contracts/core/interfaces/IAssetHandler.sol
@@ -114,4 +114,6 @@ interface IAssetHandler {
    * @return True if the token is enabled as collateral; otherwise false.
    */
   function isCollateralEnabled(address token, address vault, address controller) external view returns (bool);
+
+  function getUnderlyingToken(address token) external view returns (address);
 }

--- a/contracts/handler/Aave/AaveAssetHandler.sol
+++ b/contracts/handler/Aave/AaveAssetHandler.sol
@@ -249,6 +249,15 @@ contract AaveAssetHandler is IAssetHandler {
   }
 
   /**
+   * @notice Returns the underlying token of a Aave token.
+   * @param token The address of the Aave token.
+   * @return underlyingToken The address of the underlying token.
+   */
+  function getUnderlyingToken(address token) external pure override returns (address) {
+    return IAaveToken(token).UNDERLYING_ASSET_ADDRESS();
+  }
+
+  /**
    * @notice Retrieves all protocol assets (both lent and borrowed) for a specific account.
    * @param account The address of the user account.
    * @param comptroller The address of the Venus Comptroller.

--- a/contracts/handler/Venus/VenusAssetHandler.sol
+++ b/contracts/handler/Venus/VenusAssetHandler.sol
@@ -269,6 +269,16 @@ contract VenusAssetHandler is IAssetHandler, ExponentialNoError {
     );
   }
 
+
+  /**
+   * @notice Returns the underlying token of a Venus pool.
+   * @param token The address of the Venus pool.
+   * @return underlyingToken The address of the underlying token.
+   */
+  function getUnderlyingToken(address token) external view override returns (address) {
+    return IVenusPool(token).underlying();
+  }
+
   function swapTokens(
     address tokenIn,
     address tokenOut,

--- a/contracts/rebalance/Rebalancing.sol
+++ b/contracts/rebalance/Rebalancing.sol
@@ -13,6 +13,7 @@ import { IBorrowManager } from "../core/interfaces/IBorrowManager.sol";
 import { IAssetManagementConfig } from "../config/assetManagement/IAssetManagementConfig.sol";
 import { FunctionParameters } from "../FunctionParameters.sol";
 import { IPositionManager } from "../wrappers/abstract/IPositionManager.sol";
+import { IVenusPool } from "../core/interfaces/IVenusPool.sol";
 
 /**
  * @title RebalancingCore
@@ -320,10 +321,12 @@ contract Rebalancing is
       protocolConfig.marketControllers(_repayAddress)
     );
 
+
     // Check if the token is still in the borrowed list
     bool isTokenBorrowed = false;
     for (uint i = 0; i < borrowedTokensAfter.length; i++) {
-      if (borrowedTokensAfter[i] == _debtToken) {
+      address token = IVenusPool(borrowedTokensAfter[i]).underlying();
+      if (token == _debtToken) {
         isTokenBorrowed = true;
         break;
       }
@@ -507,6 +510,7 @@ contract Rebalancing is
     uint256 borrowedLengthBefore = (
       assetHandler.getBorrowedTokens(_vault, _controller)
     ).length;
+
 
     // Setting token as collateral
     portfolio.vaultInteraction(_controller, 0, assetHandler.enterMarket(_tokens));

--- a/contracts/rebalance/Rebalancing.sol
+++ b/contracts/rebalance/Rebalancing.sol
@@ -325,7 +325,7 @@ contract Rebalancing is
     // Check if the token is still in the borrowed list
     bool isTokenBorrowed = false;
     for (uint i = 0; i < borrowedTokensAfter.length; i++) {
-      address token = IVenusPool(borrowedTokensAfter[i]).underlying();
+      address token = assetHandler.getUnderlyingToken(borrowedTokensAfter[i]);
       if (token == _debtToken) {
         isTokenBorrowed = true;
         break;

--- a/test/Bsc/10_Stratergy.test.ts
+++ b/test/Bsc/10_Stratergy.test.ts
@@ -4,6 +4,7 @@ import "@nomicfoundation/hardhat-chai-matchers";
 import { ethers, network, upgrades } from "hardhat";
 import { BigNumber, Contract } from "ethers";
 import VENUS_CHAINLINK_ORACLE_ABI from "../abi/venus_chainlink_oracle.json";
+import BINANCE_ORACLE_ABI from "../abi/binance_oracle.json";
 
 import {
   PERMIT2_ADDRESS,
@@ -232,6 +233,7 @@ describe.only("Tests for Deposit", () => {
       );
 
       const chainLinkOracle = "0x1B2103441A0A108daD8848D8F5d790e4D402921F";
+      const binanceOracle = "0x594810b741d136f1960141C0d8Fb4a91bE78A820";
 
       let oracle = new ethers.Contract(
         chainLinkOracle,
@@ -239,13 +241,26 @@ describe.only("Tests for Deposit", () => {
         owner.provider
       );
 
+      let binance_Oracle = new ethers.Contract(
+        binanceOracle,
+        BINANCE_ORACLE_ABI,
+        owner.provider
+      );
+
       let oracleOwner = await oracle.owner();
+      let binance_OracleOwner = await binance_Oracle.owner();
 
       await network.provider.request({
         method: "hardhat_impersonateAccount",
         params: [oracleOwner],
       });
       const oracleSigner = await ethers.getSigner(oracleOwner);
+
+      await network.provider.request({
+        method: "hardhat_impersonateAccount",
+        params: [binance_OracleOwner],
+      });
+      const binance_OracleSigner = await ethers.getSigner(binance_OracleOwner);
 
       const tx = await oracle.connect(oracleSigner).setTokenConfigs([
         {
@@ -263,8 +278,15 @@ describe.only("Tests for Deposit", () => {
           feed: "0x264990fbd0A4796A3E3d8E37C4d5F87a3aCa5Ebf",
           maxStalePeriod: "31536000",
         },
+        {
+          asset: "0x55d398326f99059fF775485246999027B3197955",
+          feed: "0xb97ad0e74fa7d920791e90258a6e2085088b4320",
+          maxStalePeriod: "31536000",
+        }
       ]);
       await tx.wait();
+
+      await binance_Oracle.connect(binance_OracleSigner).setMaxStalePeriod("BNB", "31536000");
 
       const PancakeswapHandler = await ethers.getContractFactory(
         "PancakeSwapHandler"

--- a/test/Bsc/11_DexRepayment.test.ts
+++ b/test/Bsc/11_DexRepayment.test.ts
@@ -4,6 +4,7 @@ import "@nomicfoundation/hardhat-chai-matchers";
 import { ethers, network, upgrades } from "hardhat";
 import { BigNumber, Contract } from "ethers";
 import VENUS_CHAINLINK_ORACLE_ABI from "../abi/venus_chainlink_oracle.json";
+import BINANCE_ORACLE_ABI from "../abi/binance_oracle.json";
 
 import {
   createEnsoCallData,
@@ -168,6 +169,7 @@ describe.only("Tests for Deposit", () => {
       );
 
       const chainLinkOracle = "0x1B2103441A0A108daD8848D8F5d790e4D402921F";
+      const binanceOracle = "0x594810b741d136f1960141C0d8Fb4a91bE78A820";
 
       let oracle = new ethers.Contract(
         chainLinkOracle,
@@ -175,15 +177,26 @@ describe.only("Tests for Deposit", () => {
         owner.provider
       );
 
-      console.log("oracle", oracle.address);
+      let binance_Oracle = new ethers.Contract(
+        binanceOracle,
+        BINANCE_ORACLE_ABI,
+        owner.provider
+      );
 
       let oracleOwner = await oracle.owner();
+      let binance_OracleOwner = await binance_Oracle.owner();
 
       await network.provider.request({
         method: "hardhat_impersonateAccount",
         params: [oracleOwner],
       });
       const oracleSigner = await ethers.getSigner(oracleOwner);
+
+      await network.provider.request({
+        method: "hardhat_impersonateAccount",
+        params: [binance_OracleOwner],
+      });
+      const binance_OracleSigner = await ethers.getSigner(binance_OracleOwner);
 
       const tx = await oracle.connect(oracleSigner).setTokenConfigs([
         {
@@ -201,8 +214,15 @@ describe.only("Tests for Deposit", () => {
           feed: "0x264990fbd0A4796A3E3d8E37C4d5F87a3aCa5Ebf",
           maxStalePeriod: "31536000",
         },
+        {
+          asset: "0x55d398326f99059fF775485246999027B3197955",
+          feed: "0xb97ad0e74fa7d920791e90258a6e2085088b4320",
+          maxStalePeriod: "31536000",
+        }
       ]);
       await tx.wait();
+
+      await binance_Oracle.connect(binance_OracleSigner).setMaxStalePeriod("BNB", "31536000");
 
       const PancakeSwapHandler = await ethers.getContractFactory(
         "PancakeSwapHandler"

--- a/test/abi/binance_oracle.json
+++ b/test/abi/binance_oracle.json
@@ -1,0 +1,366 @@
+[
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "calledContract",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "methodSignature",
+          "type": "string"
+        }
+      ],
+      "name": "Unauthorized",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "string",
+          "name": "asset",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "maxStalePeriod",
+          "type": "uint256"
+        }
+      ],
+      "name": "MaxStalePeriodAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "oldAccessControlManager",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newAccessControlManager",
+          "type": "address"
+        }
+      ],
+      "name": "NewAccessControlManager",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferStarted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "string",
+          "name": "symbol",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "overriddenSymbol",
+          "type": "string"
+        }
+      ],
+      "name": "SymbolOverridden",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "BNB_ADDR",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "acceptOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "accessControlManager",
+      "outputs": [
+        {
+          "internalType": "contract IAccessControlManagerV8",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getFeedRegistryAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "asset",
+          "type": "address"
+        }
+      ],
+      "name": "getPrice",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_sidRegistryAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_accessControlManager",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "name": "maxStalePeriod",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pendingOwner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "accessControlManager_",
+          "type": "address"
+        }
+      ],
+      "name": "setAccessControlManager",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_maxStalePeriod",
+          "type": "uint256"
+        }
+      ],
+      "name": "setMaxStalePeriod",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "symbol",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "overrideSymbol",
+          "type": "string"
+        }
+      ],
+      "name": "setSymbolOverride",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sidRegistryAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "name": "symbols",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+  


### PR DESCRIPTION
We implemented a change suggested by the Cantina researcher to ensure that during full repayment, the value of tokensBorrowed is correctly decremented—this was a valid observation.

However, there was a mistake in the implementation. I mistakenly compared the vToken directly with the regular ERC20 _debtToken. As a result, the condition:

`if (borrowedTokensAfter[i] == _debtToken)`
was always false, causing the if (!isTokenBorrowed) block to execute every time and incorrectly decrement tokensBorrowed on each execution.

The fix was simple: instead of comparing the vToken, we needed to compare its underlying asset with _debtToken.