### PR TITLE
Rebalance external position fix

### DIFF
--- a/contracts/handler/ExternalSwapHandler/EnsoHandler.sol
+++ b/contracts/handler/ExternalSwapHandler/EnsoHandler.sol
@@ -108,7 +108,7 @@ contract EnsoHandler is IIntentHandler, ExternalPositionManagement {
       // Two-dimensional to match the structure of callDataIncreaseLiquidity
       address[] memory underlyingTokensDecreaseLiquidity, // Array of underlying tokens for decreasing liquidity
       // One-dimensional as it's a flat list of tokens
-      address[] memory tokensIn, // Array of input token addresses
+      address[][] memory tokensIn, // Array of input token addresses, two-dimensional to match output structure
       address[][] memory tokensOut, // Array of output token addresses
       uint256[][] memory minExpectedOutputAmounts // Array of minimum expected output amounts
     ) = abi.decode(
@@ -119,7 +119,7 @@ contract EnsoHandler is IIntentHandler, ExternalPositionManagement {
           bytes[][],
           address[][],
           address[],
-          address[],
+          address[][],
           address[][],
           uint256[][]
         )
@@ -153,10 +153,10 @@ contract EnsoHandler is IIntentHandler, ExternalPositionManagement {
         address(_params._positionManager) != address(0) && // PositionManager has not been initialized
         IExternalPositionStorage(
           IPositionManager(_params._positionManager).externalPositionStorage()
-        ).isWrappedPosition(tokensIn[i])
+        ).isWrappedPosition(tokensIn[i][0])
       ) {
         _handleWrappedPositionDecrease(
-          IPositionWrapper(tokensIn[i]).parentPositionManager(),
+          IPositionWrapper(tokensIn[i][0]).parentPositionManager(),
           callDataDecreaseLiquidity[i]
         );
       }

--- a/test/Arbitrum/4_Deposits.test.ts
+++ b/test/Arbitrum/4_Deposits.test.ts
@@ -1170,10 +1170,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1257,10 +1258,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1366,10 +1368,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1447,10 +1450,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1528,10 +1532,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1644,11 +1649,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -1690,11 +1695,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -1735,11 +1740,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -1787,7 +1792,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1797,7 +1802,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1847,7 +1852,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1857,7 +1862,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyTokenManipulated]],
             [[0]],
           ]
@@ -1909,7 +1914,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1919,7 +1924,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1962,11 +1967,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0, 0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0, 0]]]
         );
 
         await expect(
@@ -2001,7 +2006,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -2011,7 +2016,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -2049,11 +2054,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -2098,7 +2103,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -2108,7 +2113,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -2151,11 +2156,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -2198,7 +2203,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -2208,7 +2213,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -2257,7 +2262,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -2267,7 +2272,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]

--- a/test/Arbitrum/8_Borrowing.test.ts
+++ b/test/Arbitrum/8_Borrowing.test.ts
@@ -153,10 +153,10 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         { kind: "uups" }
       );
 
-      const UniSwapHandler = await ethers.getContractFactory(
-        "UniswapHandler"
+      const UniSwapHandler = await ethers.getContractFactory("UniswapHandler");
+      swapHandler = await UniSwapHandler.deploy(
+        addresses.UniswapV3RouterAddress
       );
-      swapHandler = await UniSwapHandler.deploy(addresses.UniswapV3RouterAddress);
       await swapHandler.deployed();
 
       protocolConfig = ProtocolConfig.attach(_protocolConfig.address);
@@ -558,7 +558,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -568,7 +568,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -631,7 +631,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -641,7 +641,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1105,10 +1105,10 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _solverHandler: ensoHandler.address, //Handler to swap
             _swapHandler: swapHandler.address,
             _flashLoanAmount: [flashLoanAmount],
-            _poolFees :[[]],
+            _poolFees: [[]],
             firstSwapData: [encodedParameters],
             secondSwapData: [encodedParameters1],
-            isDexRepayment : false
+            isDexRepayment: false,
           },
           responses
         );

--- a/test/Arbitrum/9_DexRepayment.test.ts
+++ b/test/Arbitrum/9_DexRepayment.test.ts
@@ -556,7 +556,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -566,7 +566,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -629,7 +629,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -639,7 +639,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]

--- a/test/Bsc/10_Stratergy.test.ts
+++ b/test/Bsc/10_Stratergy.test.ts
@@ -282,11 +282,13 @@ describe.only("Tests for Deposit", () => {
           asset: "0x55d398326f99059fF775485246999027B3197955",
           feed: "0xb97ad0e74fa7d920791e90258a6e2085088b4320",
           maxStalePeriod: "31536000",
-        }
+        },
       ]);
       await tx.wait();
 
-      await binance_Oracle.connect(binance_OracleSigner).setMaxStalePeriod("BNB", "31536000");
+      await binance_Oracle
+        .connect(binance_OracleSigner)
+        .setMaxStalePeriod("BNB", "31536000");
 
       const PancakeswapHandler = await ethers.getContractFactory(
         "PancakeSwapHandler"
@@ -931,7 +933,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -941,7 +943,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1177,7 +1179,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1187,7 +1189,7 @@ describe.only("Tests for Deposit", () => {
             callDataIncreaseLiquidity,
             [[token0, token1, positionManager.address]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1242,7 +1244,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1252,7 +1254,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]

--- a/test/Bsc/11_DexRepayment.test.ts
+++ b/test/Bsc/11_DexRepayment.test.ts
@@ -218,16 +218,20 @@ describe.only("Tests for Deposit", () => {
           asset: "0x55d398326f99059fF775485246999027B3197955",
           feed: "0xb97ad0e74fa7d920791e90258a6e2085088b4320",
           maxStalePeriod: "31536000",
-        }
+        },
       ]);
       await tx.wait();
 
-      await binance_Oracle.connect(binance_OracleSigner).setMaxStalePeriod("BNB", "31536000");
+      await binance_Oracle
+        .connect(binance_OracleSigner)
+        .setMaxStalePeriod("BNB", "31536000");
 
       const PancakeSwapHandler = await ethers.getContractFactory(
         "PancakeSwapHandler"
       );
-      swapHandler = await PancakeSwapHandler.deploy(addresses.PancakeSwapV3RouterAddress);
+      swapHandler = await PancakeSwapHandler.deploy(
+        addresses.PancakeSwapV3RouterAddress
+      );
       await swapHandler.deployed();
 
       protocolConfig = ProtocolConfig.attach(_protocolConfig.address);
@@ -262,7 +266,10 @@ describe.only("Tests for Deposit", () => {
       const VenusAssetHandler = await ethers.getContractFactory(
         "VenusAssetHandler"
       );
-      venusAssetHandler = await VenusAssetHandler.deploy(addresses.vBNB_Address, addresses.WETH_Address);
+      venusAssetHandler = await VenusAssetHandler.deploy(
+        addresses.vBNB_Address,
+        addresses.WETH_Address
+      );
       await venusAssetHandler.deployed();
 
       const BorrowManager = await ethers.getContractFactory(
@@ -618,7 +625,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -628,7 +635,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -692,7 +699,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -702,7 +709,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -962,7 +969,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -972,7 +979,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1075,8 +1082,8 @@ describe.only("Tests for Deposit", () => {
             [addresses.vLINK_Address],
             vault
           );
-        
-        console.log("BNB balance of vault",await provider.getBalance(vault));
+
+        console.log("BNB balance of vault", await provider.getBalance(vault));
         console.log("balanceBorrowed after repay", balanceBorrowed);
       });
 
@@ -1197,7 +1204,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1207,7 +1214,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1271,7 +1278,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1281,7 +1288,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1675,21 +1682,23 @@ describe.only("Tests for Deposit", () => {
 
         const flashLoanAmount = values[1];
 
-        await portfolio.multiTokenWithdrawal(BigNumber.from(amountPortfolioToken), {
-          _factory: addresses.thena_factory,
-          _token0: addresses.USDT, //USDT - Pool token
-          _token1: addresses.USDC_Address, //USDC - Pool token
-          _flashLoanToken: flashLoanToken, //Token to take flashlaon
-          _bufferUnit: bufferUnit,
-          _solverHandler: ensoHandler.address, //Handler to swap
-          _flashLoanAmount: [flashLoanAmount],
-          firstSwapData: [[]],
-          secondSwapData: [[]],
-          isDexRepayment: true,
-          _poolFees: [[500, 500, 500, 500, 500, 500, 500, 500, 500]],
-          _swapHandler: swapHandler.address,
-        });
-
+        await portfolio.multiTokenWithdrawal(
+          BigNumber.from(amountPortfolioToken),
+          {
+            _factory: addresses.thena_factory,
+            _token0: addresses.USDT, //USDT - Pool token
+            _token1: addresses.USDC_Address, //USDC - Pool token
+            _flashLoanToken: flashLoanToken, //Token to take flashlaon
+            _bufferUnit: bufferUnit,
+            _solverHandler: ensoHandler.address, //Handler to swap
+            _flashLoanAmount: [flashLoanAmount],
+            firstSwapData: [[]],
+            secondSwapData: [[]],
+            isDexRepayment: true,
+            _poolFees: [[500, 500, 500, 500, 500, 500, 500, 500, 500]],
+            _swapHandler: swapHandler.address,
+          }
+        );
 
         const supplyAfter = await portfolio.totalSupply();
         console.log("SupplyAfter", supplyAfter);

--- a/test/Bsc/13_Algebrav2_1Bundle.test.ts
+++ b/test/Bsc/13_Algebrav2_1Bundle.test.ts
@@ -890,7 +890,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -900,7 +900,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [await positionWrapper.token0(), await positionWrapper.token1()],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]

--- a/test/Bsc/4_Deposit.test.ts
+++ b/test/Bsc/4_Deposit.test.ts
@@ -1218,10 +1218,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1518,10 +1519,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations1.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations1.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1630,11 +1632,11 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -1733,11 +1735,11 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -1785,7 +1787,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1795,7 +1797,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1845,7 +1847,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1923,7 +1925,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1964,7 +1966,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -2013,7 +2015,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -2051,7 +2053,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -2109,7 +2111,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -2159,7 +2161,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -2269,11 +2271,11 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -2307,11 +2309,11 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -2347,11 +2349,11 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
-          [[["0x"]], [], [[]], [[]], [], [sellToken], [[buyToken]], [[0]]]
+          [[["0x"]], [], [[]], [[]], [], [[sellToken]], [[buyToken]], [[0]]]
         );
 
         await expect(
@@ -2395,7 +2397,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -2405,7 +2407,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -2474,7 +2476,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -2484,7 +2486,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            sellToken,
+            [[sellToken]],
             buyTokenArray,
             outputAmountsArray,
           ]
@@ -3153,7 +3155,7 @@ describe.only("Tests for Deposit", () => {
         await protocolConfig.enableRewardTarget(token);
 
         await expect(
-          rebalancing.claimRewardTokens(token, token,0, txData)
+          rebalancing.claimRewardTokens(token, token, 0, txData)
         ).to.be.revertedWithCustomError(rebalancing, "ClaimFailed");
       });
     });

--- a/test/Bsc/6_PositionWrapperBundle.test.ts
+++ b/test/Bsc/6_PositionWrapperBundle.test.ts
@@ -885,7 +885,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokensOut
             " uint256[][]", // minExpectedOutputAmounts (out)
           ],
@@ -895,7 +895,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [await removedPosition.token0(), await removedPosition.token1()],
-            [sellToken],
+            [[sellToken]],
             [[await removedPosition.token0(), await removedPosition.token1()]],
             [[0, 0]],
           ]
@@ -1063,7 +1063,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokensOut
             " uint256[][]", // minExpectedOutputAmounts (out)
           ],
@@ -1073,7 +1073,7 @@ describe.only("Tests for Deposit", () => {
             callDataIncreaseLiquidity,
             [[token0, token1, positionManager.address]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]

--- a/test/Bsc/9_Borrowing.test.ts
+++ b/test/Bsc/9_Borrowing.test.ts
@@ -218,16 +218,20 @@ describe.only("Tests for Deposit", () => {
           asset: "0x55d398326f99059fF775485246999027B3197955",
           feed: "0xb97ad0e74fa7d920791e90258a6e2085088b4320",
           maxStalePeriod: "31536000",
-        }
+        },
       ]);
       await tx.wait();
 
-      await binance_Oracle.connect(binance_OracleSigner).setMaxStalePeriod("BNB", "31536000");
+      await binance_Oracle
+        .connect(binance_OracleSigner)
+        .setMaxStalePeriod("BNB", "31536000");
 
       const PancakeSwapHandler = await ethers.getContractFactory(
         "PancakeSwapHandler"
       );
-      swapHandler = await PancakeSwapHandler.deploy(addresses.PancakeSwapV3RouterAddress);
+      swapHandler = await PancakeSwapHandler.deploy(
+        addresses.PancakeSwapV3RouterAddress
+      );
       await swapHandler.deployed();
 
       protocolConfig = ProtocolConfig.attach(_protocolConfig.address);
@@ -262,7 +266,10 @@ describe.only("Tests for Deposit", () => {
       const VenusAssetHandler = await ethers.getContractFactory(
         "VenusAssetHandler"
       );
-      venusAssetHandler = await VenusAssetHandler.deploy(addresses.vBNB_Address, addresses.WETH_Address);
+      venusAssetHandler = await VenusAssetHandler.deploy(
+        addresses.vBNB_Address,
+        addresses.WETH_Address
+      );
       await venusAssetHandler.deployed();
 
       const BorrowManager = await ethers.getContractFactory(
@@ -618,7 +625,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -628,7 +635,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -692,7 +699,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -702,7 +709,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -962,7 +969,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -972,7 +979,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1227,7 +1234,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1237,7 +1244,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]
@@ -1301,7 +1308,7 @@ describe.only("Tests for Deposit", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             " uint256[][]", // minExpectedOutputAmounts
           ],
@@ -1311,7 +1318,7 @@ describe.only("Tests for Deposit", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]

--- a/test/base/1_MetaAggregatorTest.test.ts
+++ b/test/base/1_MetaAggregatorTest.test.ts
@@ -594,7 +594,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -604,7 +604,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]

--- a/test/base/2_EnsoTest.test.ts
+++ b/test/base/2_EnsoTest.test.ts
@@ -595,7 +595,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -605,7 +605,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]

--- a/test/base/3_MetaEnsoTest.test.ts
+++ b/test/base/3_MetaEnsoTest.test.ts
@@ -646,7 +646,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             "bytes[][]", // callDataIncreaseLiquidity
             "address[][]", // increaseLiquidityTarget
             "address[]", // underlyingTokensDecreaseLiquidity
-            "address[]", // tokensIn
+            "address[][]", // tokensIn
             "address[][]", // tokens
             "uint256[][]", // minExpectedOutputAmounts
           ],
@@ -656,7 +656,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             [[]],
             [[]],
             [],
-            [sellToken],
+            [[sellToken]],
             [[buyToken]],
             [[0]],
           ]


### PR DESCRIPTION
EnsoHandler requires length of tokensIn == tokensOut but the tokensOut is a two dimensional array and tokensIn wasn't

It requires some change for the scenario where we rebalance two underlying tokens in the portfolio, e.g., WBNB and ETH to a position. In that case we have two input token but only one output token

Here is a test case testing the scenario that was failing: https://gist.github.com/langnavina97/f271201c3e020dc4cc36751c28578d3d