### PR TITLE
Fee collection fix

### DIFF
--- a/contracts/wrappers/WrapperFunctionParameters.sol
+++ b/contracts/wrappers/WrapperFunctionParameters.sol
@@ -154,4 +154,25 @@ library WrapperFunctionParameters {
     int24 _tickUpper;
     uint24 _fee;
   }
+
+  /**
+   * @param _positionWrapper An interface to the position wrapper that manages interactions with the Uniswap V3 positions.
+   * @param _tokenId The ID of the Uniswap V3 position from which fees are to be collected.
+   * @param _token0 The address of the first token in the Uniswap V3 position.
+   * @param _token1 The address of the second token in the Uniswap V3 position.
+   * @param tokenIn The address of the token to be swapped (input).
+   * @param tokenOut The address of the token to be received (output).
+   * @param amountIn The amount of `tokenIn` to be swapped to `tokenOut`.
+   */
+  struct CollectFeesParams {
+    IPositionWrapper _positionWrapper;
+    uint256 _tokenId;
+    address _deployer;
+    address _token0;
+    address _token1;
+    address _tokenIn;
+    address _tokenOut;
+    uint256 _amountIn;
+    uint24 _fee;
+  }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ccd9b480-c954-4928-9d33-1aa46b71ad74)

When collecting fees for the last withdrawal without reinvesting them the fees were getting stuck in the contract because we calculated the balanceBefore after. We need to calculate the balance before when not reinvesting the fees