### PR TITLE
Added max repayment in withdrawal

### DIFF
--- a/contracts/handler/Aave/AaveAssetHandler.sol
+++ b/contracts/handler/Aave/AaveAssetHandler.sol
@@ -1296,6 +1296,8 @@ contract AaveAssetHandler is IAssetHandler {
         isDexRepayment: repayData.isDexRepayment
       });
 
+
+    address receiver = _receiver;
     // Initiate the flash loan from the Algebra pool
     address[] memory assets = new address[](1);
     assets[0] = repayData._flashLoanToken;
@@ -1303,8 +1305,6 @@ contract AaveAssetHandler is IAssetHandler {
     amounts[0] = totalFlashAmount;
     uint256[] memory interestRateModes = new uint256[](1);
     interestRateModes[0] = 0;
-
-    address receiver = _receiver;
 
     IAavePool(repayData._token0).flashLoan(
       receiver,

--- a/contracts/handler/Aave/AaveAssetHandler.sol
+++ b/contracts/handler/Aave/AaveAssetHandler.sol
@@ -1275,6 +1275,8 @@ contract AaveAssetHandler is IAssetHandler {
       }
     }
 
+    bool isMaxRepayment = _portfolioTokenAmount == _totalSupply;
+
     // Prepare the flash loan data to be used in the flash loan callback
     FunctionParameters.FlashLoanData memory flashData = FunctionParameters
       .FlashLoanData({
@@ -1290,7 +1292,7 @@ contract AaveAssetHandler is IAssetHandler {
         poolFees: repayData._poolFees[_counter],
         firstSwapData: repayData.firstSwapData[_counter],
         secondSwapData: repayData.secondSwapData[_counter],
-        isMaxRepayment: false,
+        isMaxRepayment: isMaxRepayment,
         isDexRepayment: repayData.isDexRepayment
       });
 

--- a/contracts/handler/Venus/VenusAssetHandler.sol
+++ b/contracts/handler/Venus/VenusAssetHandler.sol
@@ -1549,6 +1549,7 @@ contract VenusAssetHandler is IAssetHandler, ExponentialNoError {
     underlying = new address[](borrowedLength);
     tokenBalance = new uint256[](borrowedLength);
 
+
     for (uint256 i; i < borrowedLength; ) {
       address token = borrowedTokens[i];
       uint256 borrowedAmount = IVenusPool(token).borrowBalanceStored(_vault); // Get the current borrowed balance for the token
@@ -1566,6 +1567,8 @@ contract VenusAssetHandler is IAssetHandler, ExponentialNoError {
       repayData._token1
     );
 
+    bool isMaxRepayment = _portfolioTokenAmount == _totalSupply;
+
     // Prepare the flash loan data to be used in the flash loan callback
     FunctionParameters.FlashLoanData memory flashData = FunctionParameters
       .FlashLoanData({
@@ -1581,7 +1584,7 @@ contract VenusAssetHandler is IAssetHandler, ExponentialNoError {
         poolFees: repayData._poolFees[_counter],
         firstSwapData: repayData.firstSwapData[_counter],
         secondSwapData: repayData.secondSwapData[_counter],
-        isMaxRepayment: false,
+        isMaxRepayment: isMaxRepayment,
         isDexRepayment: repayData.isDexRepayment
       });
     // Initiate the flash loan from the Algebra pool


### PR DESCRIPTION
In assetHandlers, the maxRepayment logic was missing during withdrawals. This will cause an issue where, even when the last user attempts to withdraw, some borrowed tokens remain unpaid. As a result, a portion of the collateral also remains locked, preventing complete withdrawal.