### PR TITLE
Deposit min0fix

### DIFF
--- a/contracts/front-end-helpers/PortfolioCalculations.sol
+++ b/contracts/front-end-helpers/PortfolioCalculations.sol
@@ -145,7 +145,7 @@ contract PortfolioCalculations is ExponentialNoError {
     IProtocolConfig _protocolConfig = IProtocolConfig(
       portfolio.protocolConfig()
     );
-    (uint256[] memory vaultBalance, ) = TokenBalanceLibrary.getTokenBalancesOf(
+    uint256[] memory vaultBalance = TokenBalanceLibrary.getTokenBalancesOf(
       portfolio.getTokens(),
       portfolio.vault(),
       _protocolConfig
@@ -257,7 +257,7 @@ contract PortfolioCalculations is ExponentialNoError {
     for (uint256 i = 0; i < tokensLength; i++) {
       address _token = tokens[i];
       // Calculate the proportion of each token to return based on the burned portfolio tokens.
-      (uint256 tokenBalance, ) = TokenBalanceLibrary._getAdjustedTokenBalance(
+      uint256 tokenBalance = TokenBalanceLibrary._getAdjustedTokenBalance(
         _token,
         _vault,
         _protocolConfig,

--- a/contracts/handler/Aave/AaveAssetHandler.sol
+++ b/contracts/handler/Aave/AaveAssetHandler.sol
@@ -1296,6 +1296,8 @@ contract AaveAssetHandler is IAssetHandler {
         isDexRepayment: repayData.isDexRepayment
       });
 
+
+    address receiver = _receiver;
     // Initiate the flash loan from the Algebra pool
     address[] memory assets = new address[](1);
     assets[0] = repayData._flashLoanToken;
@@ -1303,8 +1305,6 @@ contract AaveAssetHandler is IAssetHandler {
     amounts[0] = totalFlashAmount;
     uint256[] memory interestRateModes = new uint256[](1);
     interestRateModes[0] = 0;
-
-    address receiver = _receiver;
 
     IAavePool(repayData._token0).flashLoan(
       receiver,

--- a/contracts/handler/Aave/AaveAssetHandler.sol
+++ b/contracts/handler/Aave/AaveAssetHandler.sol
@@ -1275,6 +1275,8 @@ contract AaveAssetHandler is IAssetHandler {
       }
     }
 
+    bool isMaxRepayment = _portfolioTokenAmount == _totalSupply;
+
     // Prepare the flash loan data to be used in the flash loan callback
     FunctionParameters.FlashLoanData memory flashData = FunctionParameters
       .FlashLoanData({
@@ -1290,7 +1292,7 @@ contract AaveAssetHandler is IAssetHandler {
         poolFees: repayData._poolFees[_counter],
         firstSwapData: repayData.firstSwapData[_counter],
         secondSwapData: repayData.secondSwapData[_counter],
-        isMaxRepayment: false,
+        isMaxRepayment: isMaxRepayment,
         isDexRepayment: repayData.isDexRepayment
       });
 

--- a/contracts/handler/Venus/VenusAssetHandler.sol
+++ b/contracts/handler/Venus/VenusAssetHandler.sol
@@ -1549,6 +1549,7 @@ contract VenusAssetHandler is IAssetHandler, ExponentialNoError {
     underlying = new address[](borrowedLength);
     tokenBalance = new uint256[](borrowedLength);
 
+
     for (uint256 i; i < borrowedLength; ) {
       address token = borrowedTokens[i];
       uint256 borrowedAmount = IVenusPool(token).borrowBalanceStored(_vault); // Get the current borrowed balance for the token
@@ -1566,6 +1567,8 @@ contract VenusAssetHandler is IAssetHandler, ExponentialNoError {
       repayData._token1
     );
 
+    bool isMaxRepayment = _portfolioTokenAmount == _totalSupply;
+
     // Prepare the flash loan data to be used in the flash loan callback
     FunctionParameters.FlashLoanData memory flashData = FunctionParameters
       .FlashLoanData({
@@ -1581,7 +1584,7 @@ contract VenusAssetHandler is IAssetHandler, ExponentialNoError {
         poolFees: repayData._poolFees[_counter],
         firstSwapData: repayData.firstSwapData[_counter],
         secondSwapData: repayData.secondSwapData[_counter],
-        isMaxRepayment: false,
+        isMaxRepayment: isMaxRepayment,
         isDexRepayment: repayData.isDexRepayment
       });
     // Initiate the flash loan from the Algebra pool

--- a/contracts/mock/upgradeability/changedDependencies/v3_2/VaultManagerV3_2.sol
+++ b/contracts/mock/upgradeability/changedDependencies/v3_2/VaultManagerV3_2.sol
@@ -224,7 +224,7 @@ abstract contract VaultManagerV3_2 is
     for (uint256 i; i < portfolioTokenLength; i++) {
       address _token = portfolioTokens[i];
       // Calculate the proportion of each token to return based on the burned portfolio tokens.
-      (uint256 tokenBalance, bool isCollateralEnabled) = TokenBalanceLibrary._getAdjustedTokenBalance(
+      uint256 tokenBalance = TokenBalanceLibrary._getAdjustedTokenBalance(
         portfolioTokens[i],
         vault,
         _protocolConfig,
@@ -334,9 +334,8 @@ abstract contract VaultManagerV3_2 is
     }
 
     // Get current token balances in the vault for ratio calculations
-    (
-      uint256[] memory tokenBalancesBefore,
-      TokenBalanceLibrary.ControllerData[] memory controllersData
+     (
+      uint256[] memory tokenBalancesBefore
     ) = TokenBalanceLibrary.getTokenBalancesOf(
         portfolioTokens,
         vault,
@@ -370,15 +369,11 @@ abstract contract VaultManagerV3_2 is
       transferAmount = (_minRatio * tokenBalanceBefore) / ONE_ETH_IN_WEI;
       _transferToVault(_from, token, transferAmount);
 
-      (uint256 tokenBalanceAfter, bool isCollateralEnabled) = TokenBalanceLibrary._getAdjustedTokenBalance(
-        token,
-        vault,
-        _protocolConfig,
-        controllersData
-      );
+      uint256 tokenBalanceAfter = IERC20Upgradeable(token).balanceOf(vault);
       uint256 currentRatio = _getDepositToVaultBalanceRatio(
         tokenBalanceAfter - tokenBalanceBefore,
         tokenBalanceAfter
+
       );
       _minRatioAfterTransfer = MathUtils._min(
         currentRatio,

--- a/contracts/mock/upgradeability/changedDependencies/v3_4/VaultManagerV3_4.sol
+++ b/contracts/mock/upgradeability/changedDependencies/v3_4/VaultManagerV3_4.sol
@@ -206,7 +206,7 @@ abstract contract VaultManagerV3_4 is
     for (uint256 i; i < portfolioTokenLength; i++) {
       address _token = portfolioTokens[i];
       // Calculate the proportion of each token to return based on the burned portfolio tokens.
-      (uint256 tokenBalance, bool isCollateralEnabled) = TokenBalanceLibrary._getAdjustedTokenBalance(
+      uint256 tokenBalance = TokenBalanceLibrary._getAdjustedTokenBalance(
         portfolioTokens[i],
         vault,
         _protocolConfig,
@@ -308,8 +308,7 @@ abstract contract VaultManagerV3_4 is
 
     // Get current token balances in the vault for ratio calculations
     (
-      uint256[] memory tokenBalancesBefore,
-      TokenBalanceLibrary.ControllerData[] memory controllersData
+      uint256[] memory tokenBalancesBefore
     ) = TokenBalanceLibrary.getTokenBalancesOf(
         portfolioTokens,
         vault,
@@ -344,12 +343,7 @@ abstract contract VaultManagerV3_4 is
       address token = portfolioTokens[i];
       transferAmount = (_minRatio * tokenBalancesBefore[i]) / ONE_ETH_IN_WEI;
       _transferToVault(_from, token, transferAmount);
-      (uint256 tokenBalanceAfter, bool isCollateralEnabled) = TokenBalanceLibrary._getAdjustedTokenBalance(
-        token,
-        vault,
-        _protocolConfig,
-        controllersData
-      );
+      uint256 tokenBalanceAfter = IERC20Upgradeable(token).balanceOf(vault);
       uint256 currentRatio = _getDepositToVaultBalanceRatio(
         tokenBalanceAfter - tokenBalanceAfter,
         tokenBalanceAfter


### PR DESCRIPTION
Fixed deposit mint
The problem occurs here:
```
_minRatioAfterTransfer = isCollateralEnabled 
    ? _minRatio 
    : MathUtils._min(currentRatio, _minRatioAfterTransfer);

```

The reasoning behind this implementation was as follows:
```
uint256 currentRatio = _getDepositToVaultBalanceRatio(
    tokenBalanceAfter - tokenBalanceBefore,
    tokenBalanceAfter
);
(uint256 tokenBalanceAfter, bool isCollateralEnabled) = TokenBalanceLibrary._getAdjustedTokenBalance(
    token,
    vault,
    _protocolConfig,
    controllersData
);

```

Here, tokenBalanceAfter was not accurate. To use the correct value would have been gas-intensive, so I attempted a workaround that has now proven to be flawed.

Borrowing Logic:
In scenarios where the vault has $10 and $2 is borrowed:
Total vault value becomes $12.
However, the actual vault value remains $10.

To determine the unused collateral:
Compute: (totalValue ($12) - debt ($2)) / totalValue ($12), which equals 83%.
Then, 83% of the total vault value ($12) is effectively $10, representing the usable collateral.
This unused collateral can be applied across multiple collateral tokens.

The Issue at Hand:
If the collateral increases, the unused collateral should also increase. However, the old value persists due to the workaround of reusing _minRatio. This shortcut was intended to save gas but introduces incorrect calculations.


Solution Implemented:
We know the token balance doesn't decrease for collateral-enabled tokens (though Aave tokens might increase slightly, this can be ignored). Therefore, we can revise the logic as follows:

1. Use the transfer amount directly.
2. Leverage balanceBefore for calculations.

Only for Collateral enabled tokens
```
uint256 currentRatio = _getDepositToVaultBalanceRatio(
    transferAmount,
    balanceBefore + transferAmount
);

```

