### PR TITLE
Improve Dust Threshold Detection by Using USD Value Instead of Fixed Token Amount

### DIFF
--- a/contracts/config/protocol/ExternalPositionManagement.sol
+++ b/contracts/config/protocol/ExternalPositionManagement.sol
@@ -17,6 +17,8 @@ abstract contract ExternalPositionManagement is OwnableCheck, Initializable {
   uint256 public allowedRatioDeviationBps;
   /// @notice The accepted slippage for fee reinvestment, measured in basis points.
   uint256 public acceptedSlippageFeeReinvestment;
+  /// @notice The dust threshold for swap amounts, measured in USD.
+  uint256 public swapAmountDustThreshold;
 
   /// @notice A mapping that stores information about enabled protocols.
   mapping(bytes32 => ProtocolInfo) public protocols;
@@ -38,6 +40,7 @@ abstract contract ExternalPositionManagement is OwnableCheck, Initializable {
   function __ExternalPositionManagement_init() internal onlyInitializing {
     allowedRatioDeviationBps = 50;
     acceptedSlippageFeeReinvestment = 100;
+    swapAmountDustThreshold = 1 ether;
   }
 
   /**

--- a/contracts/config/protocol/IProtocolConfig.sol
+++ b/contracts/config/protocol/IProtocolConfig.sol
@@ -66,7 +66,7 @@ interface IProtocolConfig {
    */
   function isProtocolPaused() external view returns (bool);
 
-  /** 
+  /**
    * @notice Returns whether the repay is currently paused.
    * @return True if the repay is paused, false otherwise.
    */
@@ -308,11 +308,15 @@ interface IProtocolConfig {
   function getPositionWrapperBaseImplementation(
     bytes32 protocolId
   ) external view returns (address);
-  function MAX_BORROW_TOKEN_LIMIT() external pure returns(uint256);
+  function MAX_BORROW_TOKEN_LIMIT() external pure returns (uint256);
 
-  function isSupportedCallbackCaller(address _callbackCaller) external view returns (bool);
+  function isSupportedCallbackCaller(
+    address _callbackCaller
+  ) external view returns (bool);
 
   function addSupportedCallbackCaller(address _callbackCaller) external;
 
   function removeSupportedCallbackCaller(address _callbackCaller) external;
+
+  function swapAmountDustThreshold() external view returns (uint256);
 }

--- a/contracts/wrappers/algebra-v1.2/LiquidityAmountsCalculationsV2.sol
+++ b/contracts/wrappers/algebra-v1.2/LiquidityAmountsCalculationsV2.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import { IPositionWrapper } from "../abstract/IPositionWrapper.sol";
 import { IFactory } from "../algebra/IFactory.sol";
 import { IPool } from "./IPool.sol";
+import { IPriceOracle } from "../../oracle/IPriceOracle.sol";
 
 import "@cryptoalgebra/integral-core/contracts/libraries/FullMath.sol";
 import "@cryptoalgebra/integral-core/contracts/libraries/Constants.sol";
@@ -70,5 +71,31 @@ library LiquidityAmountsCalculationsV2 {
 
       ratio = (normalizedAmount0 * 1e18) / normalizedAmount1;
     }
+  }
+
+  function getPoolRatioUSDBased(
+    IPositionWrapper _positionWrapper,
+    IPriceOracle _priceOracle,
+    address _factory,
+    address _token0,
+    address _token1,
+    int24 _tickLower,
+    int24 _tickUpper
+  ) internal returns (uint256 ratio) {
+    uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(_tickLower);
+    uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(_tickUpper);
+
+    (uint256 amount0, uint256 amount1) = _getUnderlyingAmounts(
+      _positionWrapper,
+      _factory,
+      sqrtRatioAX96,
+      sqrtRatioBX96,
+      1 ether
+    );
+
+    uint256 price0 = _priceOracle.convertToUSD18Decimals(_token0, amount0);
+    uint256 price1 = _priceOracle.convertToUSD18Decimals(_token1, amount1);
+
+    ratio = (price0 * 1e18) / price1;
   }
 }

--- a/contracts/wrappers/algebra-v1.2/LiquidityAmountsCalculationsV2.sol
+++ b/contracts/wrappers/algebra-v1.2/LiquidityAmountsCalculationsV2.sol
@@ -98,7 +98,7 @@ library LiquidityAmountsCalculationsV2 {
 
     // Prevent division by zero
     if (price1 == 0) {
-      return 100e18; // 100% token0 position
+      return 100e16; // 100% token0 position
     }
 
     ratio = (price0 * 1e18) / price1;

--- a/contracts/wrappers/algebra-v1.2/LiquidityAmountsCalculationsV2.sol
+++ b/contracts/wrappers/algebra-v1.2/LiquidityAmountsCalculationsV2.sol
@@ -96,6 +96,11 @@ library LiquidityAmountsCalculationsV2 {
     uint256 price0 = _priceOracle.convertToUSD18Decimals(_token0, amount0);
     uint256 price1 = _priceOracle.convertToUSD18Decimals(_token1, amount1);
 
+    // Prevent division by zero
+    if (price1 == 0) {
+      return 100e18; // 100% token0 position
+    }
+
     ratio = (price0 * 1e18) / price1;
   }
 }

--- a/contracts/wrappers/algebra-v1.2/PositionManagerAbstractAlgebraV1_2.sol
+++ b/contracts/wrappers/algebra-v1.2/PositionManagerAbstractAlgebraV1_2.sol
@@ -503,26 +503,20 @@ abstract contract PositionManagerAbstractAlgebraV1_2 is
       if (!isDust) {
         (balance0, balance1) = _swapTokenToToken(_params);
       } else {
-        SwapVerificationLibraryAlgebraV2.verifyDustSwapAmount(
+        (balance0, balance1) = SwapVerificationLibraryAlgebraV2
+          .verifyDustSwapAmount(
+            protocolConfig,
+            _params,
+            address(uniswapV3PositionManager)
+          );
+      }
+    } else {
+      (balance0, balance1) = SwapVerificationLibraryAlgebraV2
+        .verifyZeroSwapAmountForReinvestFees(
           protocolConfig,
           _params,
           address(uniswapV3PositionManager)
         );
-      }
-    } else {
-      uint256 feeAmount0 = IERC20Upgradeable(_params._token0).balanceOf(
-        address(this)
-      );
-      uint256 feeAmount1 = IERC20Upgradeable(_params._token1).balanceOf(
-        address(this)
-      );
-      SwapVerificationLibraryAlgebraV2.verifyZeroSwapAmountForReinvestFees(
-        protocolConfig,
-        _params,
-        address(uniswapV3PositionManager),
-        feeAmount0,
-        feeAmount1
-      );
     }
   }
 }

--- a/contracts/wrappers/algebra-v1.2/PositionManagerAbstractAlgebraV1_2.sol
+++ b/contracts/wrappers/algebra-v1.2/PositionManagerAbstractAlgebraV1_2.sol
@@ -500,7 +500,15 @@ abstract contract PositionManagerAbstractAlgebraV1_2 is
         _params
       );
 
-      if (!isDust) (balance0, balance1) = _swapTokenToToken(_params);
+      if (!isDust) {
+        (balance0, balance1) = _swapTokenToToken(_params);
+      } else {
+        SwapVerificationLibraryAlgebraV2.verifyDustSwapAmount(
+          protocolConfig,
+          _params,
+          address(uniswapV3PositionManager)
+        );
+      }
     } else {
       uint256 feeAmount0 = IERC20Upgradeable(_params._token0).balanceOf(
         address(this)

--- a/contracts/wrappers/algebra-v1.2/PositionManagerAbstractAlgebraV1_2.sol
+++ b/contracts/wrappers/algebra-v1.2/PositionManagerAbstractAlgebraV1_2.sol
@@ -494,7 +494,13 @@ abstract contract PositionManagerAbstractAlgebraV1_2 is
   ) internal override returns (uint256 balance0, uint256 balance1) {
     // Swap tokens to the token0 or token1 pool ratio
     if (_params._amountIn > 0) {
-      (balance0, balance1) = _swapTokenToToken(_params);
+      // check if the amount in is greater than the dust threshold
+      bool isDust = SwapVerificationLibraryAlgebraV2.checkSwapAmountIsDust(
+        protocolConfig,
+        _params
+      );
+
+      if (!isDust) (balance0, balance1) = _swapTokenToToken(_params);
     } else {
       uint256 feeAmount0 = IERC20Upgradeable(_params._token0).balanceOf(
         address(this)

--- a/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
+++ b/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
@@ -333,9 +333,9 @@ library SwapVerificationLibraryAlgebraV2 {
     balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
     balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
 
-    // pool ratio < 1% or > 99% (very one-sided positions)
-    // 1% = 1e16, 99% = 99e18
-    if (poolRatio < 1e16 || poolRatio > 99e18) {
+    // pool ratio < 1% token0 or > 99% token0 (very one-sided positions)
+    // 1% token0 = 1e16, 99% token0 = 99e16
+    if (poolRatio < 1e16 || poolRatio > 99e16) {
       return (balance0, balance1);
     }
     // else check if ratio is already correct

--- a/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
+++ b/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
@@ -23,8 +23,6 @@ import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/t
 library SwapVerificationLibraryAlgebraV2 {
   uint256 private constant TOTAL_WEIGHT = 10_000;
 
-  uint256 internal constant ACCEPTED_DUST_AMOUNT = 2 ether;
-
   /**
    * @dev Verifies the swap by comparing the sell and buy amounts using the price oracle.
    * @param _sellToken Address of the token being sold.
@@ -280,21 +278,40 @@ library SwapVerificationLibraryAlgebraV2 {
     uint256 _feeAmount1
   ) external {
     address oracle = protocolConfig.oracle();
+    uint256 swapAmountDustThreshold = protocolConfig.swapAmountDustThreshold();
+
     if (
       (_feeAmount0 > 0 &&
         IPriceOracle(oracle).convertToUSD18Decimals(
           _params._token0,
           _feeAmount0
         ) >
-        ACCEPTED_DUST_AMOUNT) ||
+        swapAmountDustThreshold) ||
       (_feeAmount1 > 0 &&
         IPriceOracle(oracle).convertToUSD18Decimals(
           _params._token1,
           _feeAmount1
         ) >
-        ACCEPTED_DUST_AMOUNT)
+        swapAmountDustThreshold)
     ) {
       verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
     }
+  }
+
+  /**
+   * @dev Checks if the swap amount is dust.
+   * @param _params Swap parameters encapsulating position and token details.
+   * @return True if the swap amount is dust, false otherwise.
+   */
+  function checkSwapAmountIsDust(
+    IProtocolConfig protocolConfig,
+    WrapperFunctionParameters.SwapParams memory _params
+  ) external view returns (bool) {
+    uint256 swapAmountDustThreshold = protocolConfig.swapAmountDustThreshold();
+    return
+      IPriceOracle(protocolConfig.oracle()).convertToUSD18Decimals(
+        _params._tokenIn,
+        _params._amountIn
+      ) < swapAmountDustThreshold;
   }
 }

--- a/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
+++ b/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
@@ -23,8 +23,7 @@ import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/t
 library SwapVerificationLibraryAlgebraV2 {
   uint256 private constant TOTAL_WEIGHT = 10_000;
 
-  /// @notice Minimum amount of fees in smallest token unit that must be collected before they can be reinvested.
-  uint256 internal constant MIN_REINVESTMENT_AMOUNT = 1000000;
+  uint256 internal constant ACCEPTED_DUST_AMOUNT = 2 ether;
 
   /**
    * @dev Verifies the swap by comparing the sell and buy amounts using the price oracle.
@@ -280,9 +279,20 @@ library SwapVerificationLibraryAlgebraV2 {
     uint256 _feeAmount0,
     uint256 _feeAmount1
   ) external {
+    address oracle = protocolConfig.oracle();
     if (
-      _feeAmount0 > MIN_REINVESTMENT_AMOUNT ||
-      _feeAmount1 > MIN_REINVESTMENT_AMOUNT
+      (_feeAmount0 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(
+          _params._token0,
+          _feeAmount0
+        ) >
+        ACCEPTED_DUST_AMOUNT) ||
+      (_feeAmount1 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(
+          _params._token1,
+          _feeAmount1
+        ) >
+        ACCEPTED_DUST_AMOUNT)
     ) {
       verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
     }

--- a/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
+++ b/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
@@ -314,4 +314,33 @@ library SwapVerificationLibraryAlgebraV2 {
         _params._amountIn
       ) < swapAmountDustThreshold;
   }
+
+  /**
+   * @dev Verifies that the swap amount is dust.
+   * @param _params Swap parameters encapsulating position and token details.
+   * @param _nftManager Address of the Non-Fungible Position Manager.
+   */
+  function verifyDustSwapAmount(
+    IProtocolConfig protocolConfig,
+    WrapperFunctionParameters.SwapParams memory _params,
+    address _nftManager
+  ) external {
+    uint256 poolRatio = LiquidityAmountsCalculationsV2.getPoolRatioUSDBased(
+      _params._positionWrapper,
+      IPriceOracle(protocolConfig.oracle()),
+      getFactoryAddress(_nftManager),
+      _params._token0,
+      _params._token1,
+      _params._tickLower,
+      _params._tickUpper
+    );
+
+    // pool ratio < 1% or > 99% (very one-sided positions)
+    // 1% = 1e16, 99% = 99e18
+    if (poolRatio < 1e16 || poolRatio > 99e18) {
+      return;
+    }
+    // else check if ratio is already correct
+    verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
+  }
 }

--- a/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
+++ b/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
@@ -265,37 +265,32 @@ library SwapVerificationLibraryAlgebraV2 {
    * This function is specifically used to ensure that any fees due for reinvestment don't exceed
    * certain thresholds before proceeding with a ratio verification step.
    * @param _params Swap parameters encapsulating position and token details.
-   * @param _feeAmount0 The amount of token0 after claiming fees including previous dust.
-   * @param _feeAmount1 The amount of token1 after claiming fees including previous dust.
    * @notice Only proceeds with the verification if either of the owed token amounts exceeds
    * the minimum reinvestment threshold.
    */
   function verifyZeroSwapAmountForReinvestFees(
     IProtocolConfig protocolConfig,
     WrapperFunctionParameters.SwapParams memory _params,
-    address _nftManager,
-    uint256 _feeAmount0,
-    uint256 _feeAmount1
-  ) external {
+    address _nftManager
+  ) external returns (uint256 balance0, uint256 balance1) {
     address oracle = protocolConfig.oracle();
     uint256 swapAmountDustThreshold = protocolConfig.swapAmountDustThreshold();
 
+    balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
+    balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
+
     if (
-      (_feeAmount0 > 0 &&
-        IPriceOracle(oracle).convertToUSD18Decimals(
-          _params._token0,
-          _feeAmount0
-        ) >
+      (balance0 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(_params._token0, balance0) >
         swapAmountDustThreshold) ||
-      (_feeAmount1 > 0 &&
-        IPriceOracle(oracle).convertToUSD18Decimals(
-          _params._token1,
-          _feeAmount1
-        ) >
+      (balance1 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(_params._token1, balance1) >
         swapAmountDustThreshold)
     ) {
       verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
     }
+
+    return (balance0, balance1);
   }
 
   /**
@@ -324,7 +319,7 @@ library SwapVerificationLibraryAlgebraV2 {
     IProtocolConfig protocolConfig,
     WrapperFunctionParameters.SwapParams memory _params,
     address _nftManager
-  ) external {
+  ) external returns (uint256 balance0, uint256 balance1) {
     uint256 poolRatio = LiquidityAmountsCalculationsV2.getPoolRatioUSDBased(
       _params._positionWrapper,
       IPriceOracle(protocolConfig.oracle()),
@@ -335,12 +330,17 @@ library SwapVerificationLibraryAlgebraV2 {
       _params._tickUpper
     );
 
+    balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
+    balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
+
     // pool ratio < 1% or > 99% (very one-sided positions)
     // 1% = 1e16, 99% = 99e18
     if (poolRatio < 1e16 || poolRatio > 99e18) {
-      return;
+      return (balance0, balance1);
     }
     // else check if ratio is already correct
     verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
+
+    return (balance0, balance1);
   }
 }

--- a/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
+++ b/contracts/wrappers/algebra-v1.2/SwapVerificationLibraryAlgebraV2.sol
@@ -333,12 +333,16 @@ library SwapVerificationLibraryAlgebraV2 {
     balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
     balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
 
-    // pool ratio < 1% token0 or > 99% token0 (very one-sided positions)
+    // Check if pool ratio indicates a very one-sided position (< 1% or > 99% token0)
+    // In such extreme positions, the calculated swap amount can be very small
+    // (e.g., only 0.0001% of one token needs to be swapped to the other)
+    // For these cases, we skip verification to avoid issues with tiny amounts
     // 1% token0 = 1e16, 99% token0 = 99e16
     if (poolRatio < 1e16 || poolRatio > 99e16) {
       return (balance0, balance1);
     }
-    // else check if ratio is already correct
+    // If not a one-sided position, check if the current ratio is already correct
+    // This verifies that the position maintains the proper token ratio without any swap
     verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
 
     return (balance0, balance1);

--- a/contracts/wrappers/algebra/LiquidityAmountsCalculations.sol
+++ b/contracts/wrappers/algebra/LiquidityAmountsCalculations.sol
@@ -98,7 +98,7 @@ library LiquidityAmountsCalculations {
 
     // Prevent division by zero
     if (price1 == 0) {
-      return 100e18; // 100% token0 position
+      return 100e16; // 100% token0 position
     }
 
     ratio = (price0 * 1e18) / price1;

--- a/contracts/wrappers/algebra/LiquidityAmountsCalculations.sol
+++ b/contracts/wrappers/algebra/LiquidityAmountsCalculations.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import { IPositionWrapper } from "../abstract/IPositionWrapper.sol";
 import { IFactory } from "../algebra/IFactory.sol";
 import { IPool } from "../interfaces/IPool.sol";
+import { IPriceOracle } from "../../oracle/IPriceOracle.sol";
 
 import "@cryptoalgebra/integral-core/contracts/libraries/FullMath.sol";
 import "@cryptoalgebra/integral-core/contracts/libraries/Constants.sol";
@@ -70,5 +71,31 @@ library LiquidityAmountsCalculations {
 
       ratio = (normalizedAmount0 * 1e18) / normalizedAmount1;
     }
+  }
+
+  function getPoolRatioUSDBased(
+    IPositionWrapper _positionWrapper,
+    IPriceOracle _priceOracle,
+    address _factory,
+    address _token0,
+    address _token1,
+    int24 _tickLower,
+    int24 _tickUpper
+  ) internal returns (uint256 ratio) {
+    uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(_tickLower);
+    uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(_tickUpper);
+
+    (uint256 amount0, uint256 amount1) = _getUnderlyingAmounts(
+      _positionWrapper,
+      _factory,
+      sqrtRatioAX96,
+      sqrtRatioBX96,
+      1 ether
+    );
+
+    uint256 price0 = _priceOracle.convertToUSD18Decimals(_token0, amount0);
+    uint256 price1 = _priceOracle.convertToUSD18Decimals(_token1, amount1);
+
+    ratio = (price0 * 1e18) / price1;
   }
 }

--- a/contracts/wrappers/algebra/LiquidityAmountsCalculations.sol
+++ b/contracts/wrappers/algebra/LiquidityAmountsCalculations.sol
@@ -96,6 +96,11 @@ library LiquidityAmountsCalculations {
     uint256 price0 = _priceOracle.convertToUSD18Decimals(_token0, amount0);
     uint256 price1 = _priceOracle.convertToUSD18Decimals(_token1, amount1);
 
+    // Prevent division by zero
+    if (price1 == 0) {
+      return 100e18; // 100% token0 position
+    }
+
     ratio = (price0 * 1e18) / price1;
   }
 }

--- a/contracts/wrappers/algebra/PositionManagerAlgebraAbstract.sol
+++ b/contracts/wrappers/algebra/PositionManagerAlgebraAbstract.sol
@@ -427,7 +427,13 @@ abstract contract PositionManagerAbstractAlgebra is PositionManagerAlgebraBase {
   ) internal override returns (uint256 balance0, uint256 balance1) {
     // Swap tokens to the token0 or token1 pool ratio
     if (_params._amountIn > 0) {
-      (balance0, balance1) = _swapTokenToToken(_params);
+      // check if the amount in is greater than the dust threshold
+      bool isDust = SwapVerificationLibraryAlgebra.checkSwapAmountIsDust(
+        protocolConfig,
+        _params
+      );
+
+      if (!isDust) (balance0, balance1) = _swapTokenToToken(_params);
     } else {
       uint256 feeAmount0 = IERC20Upgradeable(_params._token0).balanceOf(
         address(this)

--- a/contracts/wrappers/algebra/PositionManagerAlgebraAbstract.sol
+++ b/contracts/wrappers/algebra/PositionManagerAlgebraAbstract.sol
@@ -436,27 +436,20 @@ abstract contract PositionManagerAbstractAlgebra is PositionManagerAlgebraBase {
       if (!isDust) {
         (balance0, balance1) = _swapTokenToToken(_params);
       } else {
-        SwapVerificationLibraryAlgebra.verifyDustSwapAmount(
+        (balance0, balance1) = SwapVerificationLibraryAlgebra
+          .verifyDustSwapAmount(
+            protocolConfig,
+            _params,
+            address(uniswapV3PositionManager)
+          );
+      }
+    } else {
+      (balance0, balance1) = SwapVerificationLibraryAlgebra
+        .verifyZeroSwapAmountForReinvestFees(
           protocolConfig,
           _params,
           address(uniswapV3PositionManager)
         );
-      }
-    } else {
-      uint256 feeAmount0 = IERC20Upgradeable(_params._token0).balanceOf(
-        address(this)
-      );
-      uint256 feeAmount1 = IERC20Upgradeable(_params._token1).balanceOf(
-        address(this)
-      );
-
-      SwapVerificationLibraryAlgebra.verifyZeroSwapAmountForReinvestFees(
-        protocolConfig,
-        _params,
-        address(uniswapV3PositionManager),
-        feeAmount0,
-        feeAmount1
-      );
     }
   }
 

--- a/contracts/wrappers/algebra/PositionManagerAlgebraAbstract.sol
+++ b/contracts/wrappers/algebra/PositionManagerAlgebraAbstract.sol
@@ -433,7 +433,15 @@ abstract contract PositionManagerAbstractAlgebra is PositionManagerAlgebraBase {
         _params
       );
 
-      if (!isDust) (balance0, balance1) = _swapTokenToToken(_params);
+      if (!isDust) {
+        (balance0, balance1) = _swapTokenToToken(_params);
+      } else {
+        SwapVerificationLibraryAlgebra.verifyDustSwapAmount(
+          protocolConfig,
+          _params,
+          address(uniswapV3PositionManager)
+        );
+      }
     } else {
       uint256 feeAmount0 = IERC20Upgradeable(_params._token0).balanceOf(
         address(this)

--- a/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
+++ b/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
@@ -23,8 +23,6 @@ import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/t
 library SwapVerificationLibraryAlgebra {
   uint256 private constant TOTAL_WEIGHT = 10_000;
 
-  uint256 internal constant ACCEPTED_DUST_AMOUNT = 2 ether;
-
   /**
    * @dev Verifies the swap by comparing the sell and buy amounts using the price oracle.
    * @param _sellToken Address of the token being sold.
@@ -280,21 +278,39 @@ library SwapVerificationLibraryAlgebra {
     uint256 _feeAmount1
   ) external {
     address oracle = protocolConfig.oracle();
+    uint256 swapAmountDustThreshold = protocolConfig.swapAmountDustThreshold();
     if (
       (_feeAmount0 > 0 &&
         IPriceOracle(oracle).convertToUSD18Decimals(
           _params._token0,
           _feeAmount0
         ) >
-        ACCEPTED_DUST_AMOUNT) ||
+        swapAmountDustThreshold) ||
       (_feeAmount1 > 0 &&
         IPriceOracle(oracle).convertToUSD18Decimals(
           _params._token1,
           _feeAmount1
         ) >
-        ACCEPTED_DUST_AMOUNT)
+        swapAmountDustThreshold)
     ) {
       verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
     }
+  }
+
+  /**
+   * @dev Checks if the swap amount is dust.
+   * @param _params Swap parameters encapsulating position and token details.
+   * @return True if the swap amount is dust, false otherwise.
+   */
+  function checkSwapAmountIsDust(
+    IProtocolConfig protocolConfig,
+    WrapperFunctionParameters.SwapParams memory _params
+  ) external view returns (bool) {
+    uint256 swapAmountDustThreshold = protocolConfig.swapAmountDustThreshold();
+    return
+      IPriceOracle(protocolConfig.oracle()).convertToUSD18Decimals(
+        _params._tokenIn,
+        _params._amountIn
+      ) < swapAmountDustThreshold;
   }
 }

--- a/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
+++ b/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
@@ -332,9 +332,9 @@ library SwapVerificationLibraryAlgebra {
     balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
     balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
 
-    // pool ratio < 1% or > 99% (very one-sided positions)
-    // 1% = 1e16, 99% = 99e18
-    if (poolRatio < 1e16 || poolRatio > 99e18) {
+    // pool ratio < 1% token0 or > 99% token0 (very one-sided positions)
+    // 1% token0 = 1e16, 99% token0 = 99e16
+    if (poolRatio < 1e16 || poolRatio > 99e16) {
       return (balance0, balance1);
     }
     // else check if ratio is already correct

--- a/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
+++ b/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
@@ -313,4 +313,33 @@ library SwapVerificationLibraryAlgebra {
         _params._amountIn
       ) < swapAmountDustThreshold;
   }
+
+  /**
+   * @dev Verifies that the swap amount is dust.
+   * @param _params Swap parameters encapsulating position and token details.
+   * @param _nftManager Address of the Non-Fungible Position Manager.
+   */
+  function verifyDustSwapAmount(
+    IProtocolConfig protocolConfig,
+    WrapperFunctionParameters.SwapParams memory _params,
+    address _nftManager
+  ) external {
+    uint256 poolRatio = LiquidityAmountsCalculations.getPoolRatioUSDBased(
+      _params._positionWrapper,
+      IPriceOracle(protocolConfig.oracle()),
+      getFactoryAddress(_nftManager),
+      _params._token0,
+      _params._token1,
+      _params._tickLower,
+      _params._tickUpper
+    );
+
+    // pool ratio < 1% or > 99% (very one-sided positions)
+    // 1% = 1e16, 99% = 99e18
+    if (poolRatio < 1e16 || poolRatio > 99e18) {
+      return;
+    }
+    // else check if ratio is already correct
+    verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
+  }
 }

--- a/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
+++ b/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
@@ -265,36 +265,31 @@ library SwapVerificationLibraryAlgebra {
    * This function is specifically used to ensure that any fees due for reinvestment don't exceed
    * certain thresholds before proceeding with a ratio verification step.
    * @param _params Swap parameters encapsulating position and token details.
-   * @param _feeAmount0 The amount of token0 after claiming fees including previous dust.
-   * @param _feeAmount1 The amount of token1 after claiming fees including previous dust.
    * @notice Only proceeds with the verification if either of the owed token amounts exceeds
    * the minimum reinvestment threshold.
    */
   function verifyZeroSwapAmountForReinvestFees(
     IProtocolConfig protocolConfig,
     WrapperFunctionParameters.SwapParams memory _params,
-    address _nftManager,
-    uint256 _feeAmount0,
-    uint256 _feeAmount1
-  ) external {
+    address _nftManager
+  ) external returns (uint256 balance0, uint256 balance1) {
     address oracle = protocolConfig.oracle();
     uint256 swapAmountDustThreshold = protocolConfig.swapAmountDustThreshold();
+    balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
+    balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
+
     if (
-      (_feeAmount0 > 0 &&
-        IPriceOracle(oracle).convertToUSD18Decimals(
-          _params._token0,
-          _feeAmount0
-        ) >
+      (balance0 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(_params._token0, balance0) >
         swapAmountDustThreshold) ||
-      (_feeAmount1 > 0 &&
-        IPriceOracle(oracle).convertToUSD18Decimals(
-          _params._token1,
-          _feeAmount1
-        ) >
+      (balance1 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(_params._token1, balance1) >
         swapAmountDustThreshold)
     ) {
       verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
     }
+
+    return (balance0, balance1);
   }
 
   /**
@@ -323,7 +318,7 @@ library SwapVerificationLibraryAlgebra {
     IProtocolConfig protocolConfig,
     WrapperFunctionParameters.SwapParams memory _params,
     address _nftManager
-  ) external {
+  ) external returns (uint256 balance0, uint256 balance1) {
     uint256 poolRatio = LiquidityAmountsCalculations.getPoolRatioUSDBased(
       _params._positionWrapper,
       IPriceOracle(protocolConfig.oracle()),
@@ -334,12 +329,17 @@ library SwapVerificationLibraryAlgebra {
       _params._tickUpper
     );
 
+    balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
+    balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
+
     // pool ratio < 1% or > 99% (very one-sided positions)
     // 1% = 1e16, 99% = 99e18
     if (poolRatio < 1e16 || poolRatio > 99e18) {
-      return;
+      return (balance0, balance1);
     }
     // else check if ratio is already correct
     verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
+
+    return (balance0, balance1);
   }
 }

--- a/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
+++ b/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
@@ -23,8 +23,7 @@ import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/t
 library SwapVerificationLibraryAlgebra {
   uint256 private constant TOTAL_WEIGHT = 10_000;
 
-  /// @notice Minimum amount of fees in smallest token unit that must be collected before they can be reinvested.
-  uint256 internal constant MIN_REINVESTMENT_AMOUNT = 1000000;
+  uint256 internal constant ACCEPTED_DUST_AMOUNT = 2 ether;
 
   /**
    * @dev Verifies the swap by comparing the sell and buy amounts using the price oracle.
@@ -280,9 +279,20 @@ library SwapVerificationLibraryAlgebra {
     uint256 _feeAmount0,
     uint256 _feeAmount1
   ) external {
+    address oracle = protocolConfig.oracle();
     if (
-      _feeAmount0 > MIN_REINVESTMENT_AMOUNT ||
-      _feeAmount1 > MIN_REINVESTMENT_AMOUNT
+      (_feeAmount0 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(
+          _params._token0,
+          _feeAmount0
+        ) >
+        ACCEPTED_DUST_AMOUNT) ||
+      (_feeAmount1 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(
+          _params._token1,
+          _feeAmount1
+        ) >
+        ACCEPTED_DUST_AMOUNT)
     ) {
       verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
     }

--- a/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
+++ b/contracts/wrappers/algebra/SwapVerificationLibraryAlgebra.sol
@@ -332,12 +332,17 @@ library SwapVerificationLibraryAlgebra {
     balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
     balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
 
-    // pool ratio < 1% token0 or > 99% token0 (very one-sided positions)
+    // Check if pool ratio indicates a very one-sided position (< 1% or > 99% token0)
+    // In such extreme positions, the calculated swap amount can be very small
+    // (e.g., only 0.0001% of one token needs to be swapped to the other)
+    // For these cases, we skip verification to avoid issues with tiny amounts
     // 1% token0 = 1e16, 99% token0 = 99e16
     if (poolRatio < 1e16 || poolRatio > 99e16) {
       return (balance0, balance1);
     }
-    // else check if ratio is already correct
+
+    // If not a one-sided position, check if the current ratio is already correct
+    // This verifies that the position maintains the proper token ratio without any swap
     verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
 
     return (balance0, balance1);

--- a/contracts/wrappers/uniswapV3/LiquidityAmountsCalculations.sol
+++ b/contracts/wrappers/uniswapV3/LiquidityAmountsCalculations.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 import { IPositionWrapper } from "../abstract/IPositionWrapper.sol";
 import { IFactory } from "../uniswapV3/IFactory.sol";
 import { IPool } from "./IPool.sol";
+import { IPriceOracle } from "../../oracle/IPriceOracle.sol";
 
 import "@cryptoalgebra/integral-core/contracts/libraries/FullMath.sol";
 import "@cryptoalgebra/integral-core/contracts/libraries/Constants.sol";
@@ -75,5 +76,31 @@ library LiquidityAmountsCalculations {
 
       ratio = (normalizedAmount0 * 1e18) / normalizedAmount1;
     }
+  }
+
+  function getPoolRatioUSDBased(
+    IPositionWrapper _positionWrapper,
+    IPriceOracle _priceOracle,
+    address _factory,
+    address _token0,
+    address _token1,
+    int24 _tickLower,
+    int24 _tickUpper
+  ) internal returns (uint256 ratio) {
+    uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(_tickLower);
+    uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(_tickUpper);
+
+    (uint256 amount0, uint256 amount1) = _getUnderlyingAmounts(
+      _positionWrapper,
+      _factory,
+      sqrtRatioAX96,
+      sqrtRatioBX96,
+      1 ether
+    );
+
+    uint256 price0 = _priceOracle.convertToUSD18Decimals(_token0, amount0);
+    uint256 price1 = _priceOracle.convertToUSD18Decimals(_token1, amount1);
+
+    ratio = (price0 * 1e18) / price1;
   }
 }

--- a/contracts/wrappers/uniswapV3/LiquidityAmountsCalculations.sol
+++ b/contracts/wrappers/uniswapV3/LiquidityAmountsCalculations.sol
@@ -101,6 +101,11 @@ library LiquidityAmountsCalculations {
     uint256 price0 = _priceOracle.convertToUSD18Decimals(_token0, amount0);
     uint256 price1 = _priceOracle.convertToUSD18Decimals(_token1, amount1);
 
+    // Prevent division by zero
+    if (price1 == 0) {
+      return 100e18; // 100% token0 position
+    }
+
     ratio = (price0 * 1e18) / price1;
   }
 }

--- a/contracts/wrappers/uniswapV3/LiquidityAmountsCalculations.sol
+++ b/contracts/wrappers/uniswapV3/LiquidityAmountsCalculations.sol
@@ -103,7 +103,7 @@ library LiquidityAmountsCalculations {
 
     // Prevent division by zero
     if (price1 == 0) {
-      return 100e18; // 100% token0 position
+      return 100e16; // 100% token0 position
     }
 
     ratio = (price0 * 1e18) / price1;

--- a/contracts/wrappers/uniswapV3/PositionManagerAbstractUniswap.sol
+++ b/contracts/wrappers/uniswapV3/PositionManagerAbstractUniswap.sol
@@ -368,7 +368,13 @@ abstract contract PositionManagerAbstractUniswap is PositionManagerAbstract {
   ) internal override returns (uint256 balance0, uint256 balance1) {
     // Swap tokens to the token0 or token1 pool ratio
     if (_params._amountIn > 0) {
-      (balance0, balance1) = _swapTokenToToken(_params);
+      // check if the amount in is greater than the dust threshold
+      bool isDust = SwapVerificationLibraryUniswap.checkSwapAmountIsDust(
+        protocolConfig,
+        _params
+      );
+
+      if (!isDust) (balance0, balance1) = _swapTokenToToken(_params);
     } else {
       uint256 feeAmount0 = IERC20Upgradeable(_params._token0).balanceOf(
         address(this)

--- a/contracts/wrappers/uniswapV3/PositionManagerAbstractUniswap.sol
+++ b/contracts/wrappers/uniswapV3/PositionManagerAbstractUniswap.sol
@@ -377,26 +377,20 @@ abstract contract PositionManagerAbstractUniswap is PositionManagerAbstract {
       if (!isDust) {
         (balance0, balance1) = _swapTokenToToken(_params);
       } else {
-        SwapVerificationLibraryUniswap.verifyDustSwapAmount(
+        (balance0, balance1) = SwapVerificationLibraryUniswap
+          .verifyDustSwapAmount(
+            protocolConfig,
+            _params,
+            address(uniswapV3PositionManager)
+          );
+      }
+    } else {
+      (balance0, balance1) = SwapVerificationLibraryUniswap
+        .verifyZeroSwapAmountForReinvestFees(
           protocolConfig,
           _params,
           address(uniswapV3PositionManager)
         );
-      }
-    } else {
-      uint256 feeAmount0 = IERC20Upgradeable(_params._token0).balanceOf(
-        address(this)
-      );
-      uint256 feeAmount1 = IERC20Upgradeable(_params._token1).balanceOf(
-        address(this)
-      );
-      SwapVerificationLibraryUniswap.verifyZeroSwapAmountForReinvestFees(
-        protocolConfig,
-        _params,
-        address(uniswapV3PositionManager),
-        feeAmount0,
-        feeAmount1
-      );
     }
   }
 

--- a/contracts/wrappers/uniswapV3/PositionManagerAbstractUniswap.sol
+++ b/contracts/wrappers/uniswapV3/PositionManagerAbstractUniswap.sol
@@ -374,7 +374,15 @@ abstract contract PositionManagerAbstractUniswap is PositionManagerAbstract {
         _params
       );
 
-      if (!isDust) (balance0, balance1) = _swapTokenToToken(_params);
+      if (!isDust) {
+        (balance0, balance1) = _swapTokenToToken(_params);
+      } else {
+        SwapVerificationLibraryUniswap.verifyDustSwapAmount(
+          protocolConfig,
+          _params,
+          address(uniswapV3PositionManager)
+        );
+      }
     } else {
       uint256 feeAmount0 = IERC20Upgradeable(_params._token0).balanceOf(
         address(this)

--- a/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
+++ b/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
@@ -24,8 +24,7 @@ import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/t
 library SwapVerificationLibraryUniswap {
   uint256 private constant TOTAL_WEIGHT = 10_000;
 
-  /// @notice Minimum amount of fees in smallest token unit that must be collected before they can be reinvested.
-  uint256 internal constant MIN_REINVESTMENT_AMOUNT = 1000000;
+  uint256 internal constant ACCEPTED_DUST_AMOUNT = 2 ether;
 
   /**
    * @dev Verifies the swap by comparing the sell and buy amounts using the price oracle.
@@ -281,9 +280,20 @@ library SwapVerificationLibraryUniswap {
     uint256 _feeAmount0,
     uint256 _feeAmount1
   ) external {
+    address oracle = protocolConfig.oracle();
     if (
-      _feeAmount0 > MIN_REINVESTMENT_AMOUNT ||
-      _feeAmount1 > MIN_REINVESTMENT_AMOUNT
+      (_feeAmount0 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(
+          _params._token0,
+          _feeAmount0
+        ) >
+        ACCEPTED_DUST_AMOUNT) ||
+      (_feeAmount1 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(
+          _params._token1,
+          _feeAmount1
+        ) >
+        ACCEPTED_DUST_AMOUNT)
     ) {
       verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
     }

--- a/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
+++ b/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
@@ -333,9 +333,9 @@ library SwapVerificationLibraryUniswap {
     balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
     balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
 
-    // pool ratio < 1% or > 99% (very one-sided positions)
-    // 1% = 1e16, 99% = 99e18
-    if (poolRatio < 1e16 || poolRatio > 99e18) {
+    // pool ratio < 1% token0 or > 99% token0 (very one-sided positions)
+    // 1% token0 = 1e16, 99% token0 = 99e16
+    if (poolRatio < 1e16 || poolRatio > 99e16) {
       return (balance0, balance1);
     }
     // else check if ratio is already correct

--- a/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
+++ b/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
@@ -24,8 +24,6 @@ import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/t
 library SwapVerificationLibraryUniswap {
   uint256 private constant TOTAL_WEIGHT = 10_000;
 
-  uint256 internal constant ACCEPTED_DUST_AMOUNT = 2 ether;
-
   /**
    * @dev Verifies the swap by comparing the sell and buy amounts using the price oracle.
    * @param _sellToken Address of the token being sold.
@@ -281,21 +279,40 @@ library SwapVerificationLibraryUniswap {
     uint256 _feeAmount1
   ) external {
     address oracle = protocolConfig.oracle();
+    uint256 swapAmountDustThreshold = protocolConfig.swapAmountDustThreshold();
+
     if (
       (_feeAmount0 > 0 &&
         IPriceOracle(oracle).convertToUSD18Decimals(
           _params._token0,
           _feeAmount0
         ) >
-        ACCEPTED_DUST_AMOUNT) ||
+        swapAmountDustThreshold) ||
       (_feeAmount1 > 0 &&
         IPriceOracle(oracle).convertToUSD18Decimals(
           _params._token1,
           _feeAmount1
         ) >
-        ACCEPTED_DUST_AMOUNT)
+        swapAmountDustThreshold)
     ) {
       verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
     }
+  }
+
+  /**
+   * @dev Checks if the swap amount is dust.
+   * @param _params Swap parameters encapsulating position and token details.
+   * @return True if the swap amount is dust, false otherwise.
+   */
+  function checkSwapAmountIsDust(
+    IProtocolConfig protocolConfig,
+    WrapperFunctionParameters.SwapParams memory _params
+  ) external view returns (bool) {
+    uint256 swapAmountDustThreshold = protocolConfig.swapAmountDustThreshold();
+    return
+      IPriceOracle(protocolConfig.oracle()).convertToUSD18Decimals(
+        _params._tokenIn,
+        _params._amountIn
+      ) < swapAmountDustThreshold;
   }
 }

--- a/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
+++ b/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
@@ -315,4 +315,33 @@ library SwapVerificationLibraryUniswap {
         _params._amountIn
       ) < swapAmountDustThreshold;
   }
+
+  /**
+   * @dev Verifies that the swap amount is dust.
+   * @param _params Swap parameters encapsulating position and token details.
+   * @param _nftManager Address of the Non-Fungible Position Manager.
+   */
+  function verifyDustSwapAmount(
+    IProtocolConfig protocolConfig,
+    WrapperFunctionParameters.SwapParams memory _params,
+    address _nftManager
+  ) external {
+    uint256 poolRatio = LiquidityAmountsCalculations.getPoolRatioUSDBased(
+      _params._positionWrapper,
+      IPriceOracle(protocolConfig.oracle()),
+      getFactoryAddress(_nftManager),
+      _params._token0,
+      _params._token1,
+      _params._tickLower,
+      _params._tickUpper
+    );
+
+    // pool ratio < 1% or > 99% (very one-sided positions)
+    // 1% = 1e16, 99% = 99e18
+    if (poolRatio < 1e16 || poolRatio > 99e18) {
+      return;
+    }
+    // else check if ratio is already correct
+    verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
+  }
 }

--- a/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
+++ b/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
@@ -266,37 +266,31 @@ library SwapVerificationLibraryUniswap {
    * This function is specifically used to ensure that any fees due for reinvestment don't exceed
    * certain thresholds before proceeding with a ratio verification step.
    * @param _params Swap parameters encapsulating position and token details.
-   * @param _feeAmount0 The amount of token0 after claiming fees including previous dust.
-   * @param _feeAmount1 The amount of token1 after claiming fees including previous dust.
    * @notice Only proceeds with the verification if either of the owed token amounts exceeds
    * the minimum reinvestment threshold.
    */
   function verifyZeroSwapAmountForReinvestFees(
     IProtocolConfig protocolConfig,
     WrapperFunctionParameters.SwapParams memory _params,
-    address _nftManager,
-    uint256 _feeAmount0,
-    uint256 _feeAmount1
-  ) external {
+    address _nftManager
+  ) external returns (uint256 balance0, uint256 balance1) {
     address oracle = protocolConfig.oracle();
     uint256 swapAmountDustThreshold = protocolConfig.swapAmountDustThreshold();
 
+    balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
+    balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
+
     if (
-      (_feeAmount0 > 0 &&
-        IPriceOracle(oracle).convertToUSD18Decimals(
-          _params._token0,
-          _feeAmount0
-        ) >
+      (balance0 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(_params._token0, balance0) >
         swapAmountDustThreshold) ||
-      (_feeAmount1 > 0 &&
-        IPriceOracle(oracle).convertToUSD18Decimals(
-          _params._token1,
-          _feeAmount1
-        ) >
+      (balance1 > 0 &&
+        IPriceOracle(oracle).convertToUSD18Decimals(_params._token1, balance1) >
         swapAmountDustThreshold)
     ) {
       verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
     }
+    return (balance0, balance1);
   }
 
   /**
@@ -325,7 +319,7 @@ library SwapVerificationLibraryUniswap {
     IProtocolConfig protocolConfig,
     WrapperFunctionParameters.SwapParams memory _params,
     address _nftManager
-  ) external {
+  ) external returns (uint256 balance0, uint256 balance1) {
     uint256 poolRatio = LiquidityAmountsCalculations.getPoolRatioUSDBased(
       _params._positionWrapper,
       IPriceOracle(protocolConfig.oracle()),
@@ -336,12 +330,17 @@ library SwapVerificationLibraryUniswap {
       _params._tickUpper
     );
 
+    balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
+    balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
+
     // pool ratio < 1% or > 99% (very one-sided positions)
     // 1% = 1e16, 99% = 99e18
     if (poolRatio < 1e16 || poolRatio > 99e18) {
-      return;
+      return (balance0, balance1);
     }
     // else check if ratio is already correct
     verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
+
+    return (balance0, balance1);
   }
 }

--- a/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
+++ b/contracts/wrappers/uniswapV3/SwapVerificationLibraryUniswap.sol
@@ -333,12 +333,16 @@ library SwapVerificationLibraryUniswap {
     balance0 = IERC20Upgradeable(_params._token0).balanceOf(address(this));
     balance1 = IERC20Upgradeable(_params._token1).balanceOf(address(this));
 
-    // pool ratio < 1% token0 or > 99% token0 (very one-sided positions)
+    // Check if pool ratio indicates a very one-sided position (< 1% or > 99% token0)
+    // In such extreme positions, the calculated swap amount can be very small
+    // (e.g., only 0.0001% of one token needs to be swapped to the other)
+    // For these cases, we skip verification to avoid issues with tiny amounts
     // 1% token0 = 1e16, 99% token0 = 99e16
     if (poolRatio < 1e16 || poolRatio > 99e16) {
       return (balance0, balance1);
     }
-    // else check if ratio is already correct
+    // If not a one-sided position, check if the current ratio is already correct
+    // This verifies that the position maintains the proper token ratio without any swap
     verifyZeroSwapAmount(protocolConfig, _params, _nftManager);
 
     return (balance0, balance1);

--- a/test/Bsc/IntentCalculationsAlgebraV2.ts
+++ b/test/Bsc/IntentCalculationsAlgebraV2.ts
@@ -52,7 +52,7 @@ export async function createEnsoCallDataRoute(
     slippage: 700,
     tokenIn: _tokenIn,
     tokenOut: _tokenOut,
-    routingStrategy: "delegate-legacy",
+    routingStrategy: "delegate",
   };
 
   const postUrl = "https://api.enso.finance/api/v1/shortcuts/route?";

--- a/test/base/IntentCalculations.ts
+++ b/test/base/IntentCalculations.ts
@@ -49,7 +49,7 @@ export async function createEnsoCallDataRoute(
     slippage: 1000,
     tokenIn: _tokenIn,
     tokenOut: _tokenOut,
-    routingStrategy: "delegate-legacy",
+    routingStrategy: "delegate",
   };
 
   const postUrl = "https://api.enso.finance/api/v1/shortcuts/route?";


### PR DESCRIPTION
**Problem:**
The current dust threshold of 1000000 wei (MIN_REINVESTMENT_AMOUNT) is too small and causes transaction failures. A transaction with 1821689 wei (~$0.0000000067 USD) was about to fail, indicating the threshold needs adjustment. Additionally, using a fixed token amount doesn't work well across tokens with different decimals.

**Solution:**
- Replace the fixed token amount threshold with a USD-based dust detection system using the price oracle. This approach:
- Provides consistent dust detection across all tokens regardless of decimals
- Uses a meaningful USD threshold (e.g., $2) instead of arbitrary token amounts
- Prevents unnecessary swaps for truly insignificant amounts
- Reduces transaction failures from overly strict thresholds

**Changes:**
- Replace MIN_REINVESTMENT_AMOUNT = 1000000 with ACCEPTED_DUST_AMOUNT = 2 ether ($2 USD)
- Update verifyZeroSwapAmountForReinvestFees() to convert token balances to USD using price oracle
- Only proceed with ratio verification if USD value exceeds the dust threshold