### PR TITLE
Fix: Separate position wrapper and position manager concerns

### DIFF
--- a/contracts/FunctionParameters.sol
+++ b/contracts/FunctionParameters.sol
@@ -37,7 +37,7 @@ library FunctionParameters {
     address _feeModuleImplementationAddress;
     address _baseTokenRemovalVaultImplementation;
     address _baseVelvetGnosisSafeModuleAddress;
-    address _basePositionManager;
+    address _basePositionWrapper;
     address _baseExternalPositionStorage;
     address _baseBorrowManager;
     address _gnosisSingleton;
@@ -137,7 +137,7 @@ library FunctionParameters {
     address _accessController;
     address _feeModule;
     address _assetManagerTreasury;
-    address _basePositionManager;
+    address _basePositionWrapper;
     address _baseExternalPositionStorage;
     address[] _whitelistedTokens;
     bool _publicPortfolio;

--- a/contracts/PortfolioFactory.sol
+++ b/contracts/PortfolioFactory.sol
@@ -31,7 +31,7 @@ contract PortfolioFactory is
   address internal feeModuleImplementationAddress;
   address internal baseVelvetGnosisSafeModuleAddress;
   address internal baseTokenRemovalVaultAddress;
-  address internal basePositionManager;
+  address internal basePositionWrapper;
   address internal baseBorrowManager;
   address internal baseExternalPositionStorage;
 
@@ -112,7 +112,7 @@ contract PortfolioFactory is
       initData._baseAssetManagementConfigAddress == address(0) ||
       initData._feeModuleImplementationAddress == address(0) ||
       initData._baseVelvetGnosisSafeModuleAddress == address(0) ||
-      initData._basePositionManager == address(0) ||
+      initData._basePositionWrapper == address(0) ||
       initData._baseExternalPositionStorage == address(0) ||
       initData._gnosisSingleton == address(0) ||
       initData._gnosisFallbackLibrary == address(0) ||
@@ -138,7 +138,7 @@ contract PortfolioFactory is
       initData._baseTokenRemovalVaultImplementation
     );
     _setBaseBorrowManager(initData._baseBorrowManager);
-    setPositionManagerImplementationAddress(initData._basePositionManager);
+    setPositionManagerImplementationAddress(initData._basePositionWrapper);
     baseExternalPositionStorage = initData._baseExternalPositionStorage;
 
     baseVelvetGnosisSafeModuleAddress = initData
@@ -229,7 +229,7 @@ contract PortfolioFactory is
           _accessController: address(accessController),
           _feeModule: address(_feeModule),
           _assetManagerTreasury: initData._assetManagerTreasury,
-          _basePositionManager: basePositionManager,
+          _basePositionWrapper: basePositionWrapper,
           _baseExternalPositionStorage: baseExternalPositionStorage,
           _whitelistedTokens: initData._whitelistedTokens,
           _publicPortfolio: initData._public,
@@ -567,12 +567,12 @@ contract PortfolioFactory is
 
   /**
    * @notice This function is used to set the position manager implementation address
-   * @param _basePositionManager Address of the position manager to set as base
+   * @param _basePositionWrapper Address of the position manager to set as base
    */
   function setPositionManagerImplementationAddress(
-    address _basePositionManager
+    address _basePositionWrapper
   ) internal {
-    basePositionManager = _basePositionManager;
+    basePositionWrapper = _basePositionWrapper;
   }
 
   /**

--- a/contracts/config/assetManagement/AssetManagementConfig.sol
+++ b/contracts/config/assetManagement/AssetManagementConfig.sol
@@ -62,7 +62,7 @@ contract AssetManagementConfig is
     __TokenWhitelistManagement_init(
       initData._whitelistedTokens,
       address(accessController),
-      initData._basePositionManager,
+      initData._basePositionWrapper,
       initData._baseExternalPositionStorage,
       initData._whitelistTokens,
       initData._witelistedProtocolIds,

--- a/contracts/config/assetManagement/ExternalPositionManagement.sol
+++ b/contracts/config/assetManagement/ExternalPositionManagement.sol
@@ -22,7 +22,7 @@ abstract contract ExternalPositionManagement is AccessRoles {
   address public externalPositions; // Interface to interact with external positions.
   bool public uniswapV3WrapperEnabled; // Flag to indicate if the Uniswap V3 wrapper is enabled.
 
-  address basePositionManager; // Address of the base implementation for position manager cloning.
+  address public basePositionWrapper; // Address of the base implementation for position wrapper cloning.
   address accessControllerAddress; // Address of the access controller for role management.
 
   address public protocolConfig; // Address of the protocol config.
@@ -43,13 +43,13 @@ abstract contract ExternalPositionManagement is AccessRoles {
   /**
    * @notice Initializes the contract with necessary configurations for external position management.
    * @param _accessControllerAddress Address of the access controller for managing permissions.
-   * @param _basePositionManager Address of the base position manager for creating clones.
+   * @param _basePositionWrapper Address of the base position manager for creating clones.
    * @dev Internal initializer function to set up initial state.
    */
   function ExternalPositionManagement__init(
     address _protocolConfig,
     address _accessControllerAddress,
-    address _basePositionManager,
+    address _basePositionWrapper,
     address _baseExternalPositionStorage,
     bytes32[] calldata _witelistedProtocolIds
   ) internal {
@@ -65,7 +65,7 @@ abstract contract ExternalPositionManagement is AccessRoles {
     }
 
     accessControllerAddress = _accessControllerAddress;
-    basePositionManager = _basePositionManager;
+    basePositionWrapper = _basePositionWrapper;
 
     whitelistProtocols(_witelistedProtocolIds);
 
@@ -112,7 +112,9 @@ abstract contract ExternalPositionManagement is AccessRoles {
 
     // Deploy and initialize the position manager.
     ERC1967Proxy positionManagerProxy = new ERC1967Proxy(
-      basePositionManager,
+      IProtocolConfig(protocolConfig).getPositionManagerBaseImplementation(
+        protocolId
+      ),
       abi.encodeWithSelector(
         IPositionManager.init.selector,
         externalPositions,

--- a/contracts/config/assetManagement/IAssetManagementConfig.sol
+++ b/contracts/config/assetManagement/IAssetManagementConfig.sol
@@ -132,4 +132,6 @@ interface IAssetManagementConfig {
    * @return bool True if the protocol is whitelisted
    */
   function whitelistedProtocols(bytes32 protocolId) external returns (bool);
+
+  function basePositionWrapper() external returns (address);
 }

--- a/contracts/config/assetManagement/TokenWhitelistManagement.sol
+++ b/contracts/config/assetManagement/TokenWhitelistManagement.sol
@@ -27,7 +27,7 @@ abstract contract TokenWhitelistManagement is
    * @notice Initializes the contract with essential configuration details and initial whitelisted tokens.
    * @param _whitelistTokens Initial list of tokens to whitelist.
    * @param _accessControllerAddress Address of the access controller.
-   * @param _basePositionManager Address of the base position manager.
+   * @param _basePositionWrapper Address of the base position manager.
    * @param _tokenWhitelistingEnabled Flag indicating if token whitelisting is to be enabled.
    * @param _protocolConfig Address of the protocol configuration contract.
    * @dev The function sets initial whitelisted tokens if whitelisting is enabled and performs initial configuration of the contract.
@@ -35,7 +35,7 @@ abstract contract TokenWhitelistManagement is
   function __TokenWhitelistManagement_init(
     address[] calldata _whitelistTokens,
     address _accessControllerAddress,
-    address _basePositionManager,
+    address _basePositionWrapper,
     address _baseExternalPositionStorage,
     bool _tokenWhitelistingEnabled,
     bytes32[] calldata _witelistedProtocolIds,
@@ -47,7 +47,7 @@ abstract contract TokenWhitelistManagement is
     ExternalPositionManagement__init(
       _protocolConfig,
       _accessControllerAddress,
-      _basePositionManager,
+      _basePositionWrapper,
       _baseExternalPositionStorage,
       _witelistedProtocolIds
     );

--- a/contracts/config/protocol/ExternalPositionManagement.sol
+++ b/contracts/config/protocol/ExternalPositionManagement.sol
@@ -26,7 +26,7 @@ abstract contract ExternalPositionManagement is OwnableCheck, Initializable {
   struct ProtocolInfo {
     address nftManager;
     address swapRouter;
-    address positionWrapperBase;
+    address positionManagerBase;
     bool enabled;
   }
 
@@ -34,7 +34,7 @@ abstract contract ExternalPositionManagement is OwnableCheck, Initializable {
     bytes32 indexed protocolId,
     address nftManager,
     address swapRouter,
-    address positionWrapperBase
+    address positionManagerBase
   );
 
   function __ExternalPositionManagement_init() internal onlyInitializing {
@@ -48,24 +48,24 @@ abstract contract ExternalPositionManagement is OwnableCheck, Initializable {
    * @param protocolId The identifier for the protocol (e.g., keccak256("UNISWAP_V3"))
    * @param nftManager The NFT manager contract address for the protocol
    * @param swapRouter The swap router contract address for the protocol
-   * @param positionWrapperBase The position wrapper base implementation address
+   * @param positionManagerBase The position manager base implementation address
    */
   function enableProtocol(
     bytes32 protocolId,
     address nftManager,
     address swapRouter,
-    address positionWrapperBase
+    address positionManagerBase
   ) external onlyProtocolOwner {
     if (
       nftManager == address(0) ||
       swapRouter == address(0) ||
-      positionWrapperBase == address(0)
+      positionManagerBase == address(0)
     ) revert ErrorLibrary.InvalidAddress();
 
     protocols[protocolId] = ProtocolInfo({
       nftManager: nftManager,
       swapRouter: swapRouter,
-      positionWrapperBase: positionWrapperBase,
+      positionManagerBase: positionManagerBase,
       enabled: true
     });
 
@@ -73,7 +73,7 @@ abstract contract ExternalPositionManagement is OwnableCheck, Initializable {
       protocolId,
       nftManager,
       swapRouter,
-      positionWrapperBase
+      positionManagerBase
     );
   }
 
@@ -116,10 +116,10 @@ abstract contract ExternalPositionManagement is OwnableCheck, Initializable {
    * @param protocolId The identifier for the protocol.
    * @return The address of the position wrapper base implementation.
    */
-  function getPositionWrapperBaseImplementation(
+  function getPositionManagerBaseImplementation(
     bytes32 protocolId
   ) external view returns (address) {
-    return protocols[protocolId].positionWrapperBase;
+    return protocols[protocolId].positionManagerBase;
   }
 
   /**
@@ -131,7 +131,7 @@ abstract contract ExternalPositionManagement is OwnableCheck, Initializable {
     bytes32 protocolId,
     address newImplementation
   ) external onlyProtocolOwner {
-    protocols[protocolId].positionWrapperBase = newImplementation;
+    protocols[protocolId].positionManagerBase = newImplementation;
   }
 
   /**

--- a/contracts/config/protocol/IProtocolConfig.sol
+++ b/contracts/config/protocol/IProtocolConfig.sol
@@ -279,13 +279,13 @@ interface IProtocolConfig {
    * @param protocolId The identifier for the protocol (e.g., keccak256("UNISWAP_V3"))
    * @param nftManager The NFT manager contract address for the protocol
    * @param swapRouter The swap router contract address for the protocol
-   * @param positionWrapperBase The position wrapper base implementation address
+   * @param positionManagerBase The position wrapper base implementation address
    */
   function enableProtocol(
     bytes32 protocolId,
     address nftManager,
     address swapRouter,
-    address positionWrapperBase
+    address positionManagerBase
   ) external;
 
   /**
@@ -305,7 +305,7 @@ interface IProtocolConfig {
     bytes32 protocolId
   ) external view returns (address nftManager, address swapRouter);
 
-  function getPositionWrapperBaseImplementation(
+  function getPositionManagerBaseImplementation(
     bytes32 protocolId
   ) external view returns (address);
   function MAX_BORROW_TOKEN_LIMIT() external pure returns (uint256);

--- a/contracts/wrappers/algebra-v1.2/PositionManagerAbstractAlgebraV1_2.sol
+++ b/contracts/wrappers/algebra-v1.2/PositionManagerAbstractAlgebraV1_2.sol
@@ -190,7 +190,7 @@ abstract contract PositionManagerAbstractAlgebraV1_2 is
 
     // Deploy and initialize the position wrapper.
     ERC1967Proxy positionWrapperProxy = new ERC1967Proxy(
-      protocolConfig.getPositionWrapperBaseImplementation(protocolId),
+      assetManagementConfig.basePositionWrapper(),
       abi.encodeWithSelector(
         IPositionWrapper.init.selector,
         address(this),

--- a/contracts/wrappers/algebra/PositionManagerAlgebraAbstract.sol
+++ b/contracts/wrappers/algebra/PositionManagerAlgebraAbstract.sol
@@ -188,7 +188,7 @@ abstract contract PositionManagerAbstractAlgebra is PositionManagerAlgebraBase {
 
     // Deploy and initialize the position wrapper.
     ERC1967Proxy positionWrapperProxy = new ERC1967Proxy(
-      protocolConfig.getPositionWrapperBaseImplementation(protocolId),
+      assetManagementConfig.basePositionWrapper(),
       abi.encodeWithSelector(
         IPositionWrapper.init.selector,
         address(this),

--- a/contracts/wrappers/uniswapV3/PositionManagerAbstractUniswap.sol
+++ b/contracts/wrappers/uniswapV3/PositionManagerAbstractUniswap.sol
@@ -231,7 +231,7 @@ abstract contract PositionManagerAbstractUniswap is PositionManagerAbstract {
 
     // Deploy and initialize the position wrapper.
     ERC1967Proxy positionWrapperProxy = new ERC1967Proxy(
-      protocolConfig.getPositionWrapperBaseImplementation(protocolId),
+      assetManagementConfig.basePositionWrapper(),
       abi.encodeWithSelector(
         IPositionWrapper.init.selector,
         address(this),

--- a/scripts/deployBnbContract.ts
+++ b/scripts/deployBnbContract.ts
@@ -6,7 +6,8 @@
 const { ethers, upgrades, tenderly } = require("hardhat");
 import { chainIdToAddresses } from "../scripts/networkVariables";
 
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 async function main(): Promise<void> {
   let owner;
@@ -122,7 +123,10 @@ async function main(): Promise<void> {
   const swapVerificationLibrary = await SwapVerificationLibrary.deploy();
   await swapVerificationLibrary.deployed();
 
-  console.log("swapVerificationLibrary address:", swapVerificationLibrary.address);
+  console.log(
+    "swapVerificationLibrary address:",
+    swapVerificationLibrary.address
+  );
 
   await tenderly.verify({
     name: "SwapVerificationLibraryAlgebra",
@@ -132,7 +136,10 @@ async function main(): Promise<void> {
   const VenusAssetHandler = await ethers.getContractFactory(
     "VenusAssetHandler"
   );
-  const venusAssetHandler = await VenusAssetHandler.deploy(addresses.vBNB_Address, addresses.WETH_Address);
+  const venusAssetHandler = await VenusAssetHandler.deploy(
+    addresses.vBNB_Address,
+    addresses.WETH_Address
+  );
   await venusAssetHandler.deployed();
 
   console.log("venusAssetHandler address:", venusAssetHandler.address);
@@ -189,13 +196,6 @@ async function main(): Promise<void> {
     ethers.utils.toUtf8Bytes("THENA-CONCENTRATED-LIQUIDITY")
   );
 
-  await protocolConfig.enableProtocol(
-    thenaProtocolHash,
-    "0xa51adb08cbe6ae398046a23bec013979816b77ab",
-    "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
-    positionWrapperBaseAddress.address
-  );
-
   await sleep(2000); // 2 seconds
 
   await protocolConfig.enableTokens([
@@ -212,7 +212,6 @@ async function main(): Promise<void> {
   await protocolConfig.enableSolverHandler(ensoHandler.address);
 
   await protocolConfig.enableSwapHandler(swapHandler.address);
-
 
   await protocolConfig.setAssetHandlers(
     [
@@ -274,6 +273,13 @@ async function main(): Promise<void> {
   const positionManagerBaseAddress = await PositionManager.deploy(overrides);
   await positionManagerBaseAddress.deployed(overrides);
 
+  await protocolConfig.enableProtocol(
+    thenaProtocolHash,
+    "0xa51adb08cbe6ae398046a23bec013979816b77ab",
+    "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
+    positionManagerBaseAddress.address
+  );
+
   console.log("PositionManager address:", positionManagerBaseAddress.address);
 
   await tenderly.verify({
@@ -287,7 +293,10 @@ async function main(): Promise<void> {
   const externalPositionStorage = await ExternalPositionStorage.deploy();
   await externalPositionStorage.deployed();
 
-  console.log("externalPositionStorage address:", externalPositionStorage.address);
+  console.log(
+    "externalPositionStorage address:",
+    externalPositionStorage.address
+  );
 
   await tenderly.verify({
     name: "ExternalPositionStorage",
@@ -302,7 +311,10 @@ async function main(): Promise<void> {
   const amountCalculationsAlgebra = await AmountCalculationsAlgebra.deploy();
   await amountCalculationsAlgebra.deployed();
 
-  console.log("amountCalculationsAlgebra address:", amountCalculationsAlgebra.address);
+  console.log(
+    "amountCalculationsAlgebra address:",
+    amountCalculationsAlgebra.address
+  );
 
   await tenderly.verify({
     name: "AmountCalculationsAlgebra",
@@ -479,16 +491,14 @@ async function main(): Promise<void> {
     [
       {
         _basePortfolioAddress: portfolioContract.address,
-        _baseTokenExclusionManagerAddress:
-        tokenExclusionManager.address,
+        _baseTokenExclusionManagerAddress: tokenExclusionManager.address,
         _baseRebalancingAddres: rebalancingDefault.address,
-        _baseAssetManagementConfigAddress:
-          assetManagementConfig.address,
+        _baseAssetManagementConfigAddress: assetManagementConfig.address,
         _feeModuleImplementationAddress: feeModule.address,
         _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
         _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
         _baseBorrowManager: borrowManager.address,
-        _basePositionManager: positionManagerBaseAddress.address,
+        _basePositionWrapper: positionWrapperBaseAddress.address,
         _baseExternalPositionStorage: externalPositionStorage.address,
         _gnosisSingleton: addresses.gnosisSingleton,
         _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Arbitrum/1_IndexConfig.test.ts
+++ b/test/Arbitrum/1_IndexConfig.test.ts
@@ -246,7 +246,7 @@ describe.only("Tests for Portfolio Config", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,
@@ -896,7 +896,7 @@ describe.only("Tests for Portfolio Config", () => {
 
       it("claiming reward tokens should fail if protocol is paused", async () => {
         await expect(
-          rebalancing.claimRewardTokens(addresses.WETH, addresses.WETH,0, "0x")
+          rebalancing.claimRewardTokens(addresses.WETH, addresses.WETH, 0, "0x")
         ).to.be.revertedWithCustomError(rebalancing, "ProtocolIsPaused");
       });
 
@@ -948,7 +948,7 @@ describe.only("Tests for Portfolio Config", () => {
 
       it("claiming reward tokens should fail if reward target is not enabled", async () => {
         await expect(
-          rebalancing.claimRewardTokens(addresses.WETH, addresses.WETH,0,  "0x")
+          rebalancing.claimRewardTokens(addresses.WETH, addresses.WETH, 0, "0x")
         ).to.be.revertedWithCustomError(rebalancing, "RewardTargetNotEnabled");
       });
 
@@ -981,7 +981,7 @@ describe.only("Tests for Portfolio Config", () => {
       it("reward token target should be usable to claim after enabling", async () => {
         // empty calldata is passed, test case with calldata in file 4
         await expect(
-          rebalancing.claimRewardTokens(addresses.WETH, addresses.WETH,0, "0x")
+          rebalancing.claimRewardTokens(addresses.WETH, addresses.WETH, 0, "0x")
         ).to.be.revertedWithCustomError(rebalancing, "ClaimFailed");
       });
 
@@ -1786,11 +1786,10 @@ describe.only("Tests for Portfolio Config", () => {
         await portfolioFactory.setTokenRemovalVaultModule(addr1.address);
       });
 
-
       it("should fail if repay is paused", async () => {
         await protocolConfig.setRepayPause(true);
         await expect(
-           rebalancing.repay(addresses.aavePool, {
+          rebalancing.repay(addresses.aavePool, {
             _factory: addresses.aavePool,
             _token0: addresses.aavePool, //USDT - Pool token
             _token1: addresses.aavePool, //USDC - Pool token

--- a/test/Arbitrum/2_Upgradeability.test.ts
+++ b/test/Arbitrum/2_Upgradeability.test.ts
@@ -146,7 +146,9 @@ describe.only("Tests for Upgradeability", () => {
       const assetManagementConfig = await AssetManagementConfig.deploy();
       await assetManagementConfig.deployed();
 
-      const BorrowManager = await ethers.getContractFactory("BorrowManagerAave");
+      const BorrowManager = await ethers.getContractFactory(
+        "BorrowManagerAave"
+      );
       borrowManager = await BorrowManager.deploy();
       await borrowManager.deployed();
 
@@ -245,7 +247,7 @@ describe.only("Tests for Upgradeability", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,
@@ -487,10 +489,11 @@ describe.only("Tests for Upgradeability", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -829,10 +832,11 @@ describe.only("Tests for Upgradeability", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1171,10 +1175,11 @@ describe.only("Tests for Upgradeability", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1501,10 +1506,11 @@ describe.only("Tests for Upgradeability", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];

--- a/test/Arbitrum/3_Withdrawal.test.ts
+++ b/test/Arbitrum/3_Withdrawal.test.ts
@@ -129,7 +129,9 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       const assetManagementConfig = await AssetManagementConfig.deploy();
       await assetManagementConfig.deployed();
 
-      const BorrowManager = await ethers.getContractFactory("BorrowManagerAave");
+      const BorrowManager = await ethers.getContractFactory(
+        "BorrowManagerAave"
+      );
       borrowManager = await BorrowManager.deploy();
       await borrowManager.deployed();
 
@@ -228,7 +230,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,
@@ -533,10 +535,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -609,10 +612,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -721,10 +725,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];

--- a/test/Arbitrum/4_Deposits.test.ts
+++ b/test/Arbitrum/4_Deposits.test.ts
@@ -251,7 +251,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Arbitrum/5_BatchTx.test.ts
+++ b/test/Arbitrum/5_BatchTx.test.ts
@@ -162,10 +162,10 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         { kind: "uups" }
       );
 
-      const UniSwapHandler = await ethers.getContractFactory(
-        "UniswapHandler"
+      const UniSwapHandler = await ethers.getContractFactory("UniswapHandler");
+      uniswapHandler = await UniSwapHandler.deploy(
+        addresses.UniswapV3RouterAddress
       );
-      uniswapHandler = await UniSwapHandler.deploy(addresses.UniswapV3RouterAddress);
       await uniswapHandler.deployed();
 
       protocolConfig = ProtocolConfig.attach(_protocolConfig.address);
@@ -190,7 +190,9 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       const assetManagementConfig = await AssetManagementConfig.deploy();
       await assetManagementConfig.deployed();
 
-      const BorrowManager = await ethers.getContractFactory("BorrowManagerAave");
+      const BorrowManager = await ethers.getContractFactory(
+        "BorrowManagerAave"
+      );
       borrowManager = await BorrowManager.deploy();
       await borrowManager.deployed();
 
@@ -209,7 +211,6 @@ describe.only("Tests for Deposit + Withdrawal", () => {
 
       swapHandler.init(addresses.SushiSwapRouterAddress);
       await protocolConfig.enableSwapHandler(swapHandler.address);
-
 
       let whitelistedTokens = [
         addresses.ARB,
@@ -287,7 +288,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Arbitrum/6_PositionWrapperBundle.test.ts
+++ b/test/Arbitrum/6_PositionWrapperBundle.test.ts
@@ -214,13 +214,6 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         addresses.WETH,
       ]);
 
-      await protocolConfig.enableProtocol(
-        uniswapV3ProtocolHash,
-        "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
-        "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
-        positionWrapperBaseAddress.address
-      );
-
       const Rebalancing = await ethers.getContractFactory("Rebalancing");
       const rebalancingDefult = await Rebalancing.deploy();
       await rebalancingDefult.deployed();
@@ -284,6 +277,13 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       const positionManagerBaseAddress = await PositionManager.deploy();
       await positionManagerBaseAddress.deployed();
 
+      await protocolConfig.enableProtocol(
+        uniswapV3ProtocolHash,
+        "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
+        "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+        positionManagerBaseAddress.address
+      );
+
       const FeeModule = await ethers.getContractFactory("FeeModule", {});
       const feeModule = await FeeModule.deploy();
       await feeModule.deployed();
@@ -327,7 +327,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Arbitrum/7_PositionWrapper.test.ts
+++ b/test/Arbitrum/7_PositionWrapper.test.ts
@@ -171,6 +171,13 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       const positionManagerBaseAddress = await PositionManager.deploy();
       await positionManagerBaseAddress.deployed();
 
+      await protocolConfig.enableProtocol(
+        uniswapV3ProtocolHash,
+        "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
+        "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
+        positionManagerBaseAddress.address
+      );
+
       const BorrowManager = await ethers.getContractFactory(
         "BorrowManagerAave"
       );
@@ -190,13 +197,6 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       await protocolConfig.enableSolverHandler(ensoHandler.address);
       await protocolConfig.setSupportedFactory(ensoHandler.address);
       await protocolConfig.addSupportedCallbackCaller(addresses.aavePool);
-
-      await protocolConfig.enableProtocol(
-        uniswapV3ProtocolHash,
-        "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
-        "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
-        positionWrapperBaseAddress.address
-      );
 
       const TokenExclusionManager = await ethers.getContractFactory(
         "TokenExclusionManager"
@@ -291,7 +291,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Arbitrum/8_Borrowing.test.ts
+++ b/test/Arbitrum/8_Borrowing.test.ts
@@ -326,7 +326,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Arbitrum/9_DexRepayment.test.ts
+++ b/test/Arbitrum/9_DexRepayment.test.ts
@@ -324,7 +324,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Bsc/10_Stratergy.test.ts
+++ b/test/Bsc/10_Stratergy.test.ts
@@ -310,13 +310,6 @@ describe.only("Tests for Deposit", () => {
         iaddress.usdtAddress,
       ]);
 
-      await protocolConfig.enableProtocol(
-        thenaProtocolHash,
-        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
-        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
-        positionWrapperBaseAddress.address
-      );
-
       const Rebalancing = await ethers.getContractFactory("Rebalancing");
       const rebalancingDefult = await Rebalancing.deploy();
       await rebalancingDefult.deployed();
@@ -432,6 +425,13 @@ describe.only("Tests for Deposit", () => {
       const positionManagerBaseAddress = await PositionManager.deploy();
       await positionManagerBaseAddress.deployed();
 
+      await protocolConfig.enableProtocol(
+        thenaProtocolHash,
+        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
+        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
+        positionManagerBaseAddress.address
+      );
+
       const AmountCalculationsAlgebra = await ethers.getContractFactory(
         "AmountCalculationsAlgebra"
       );
@@ -481,7 +481,7 @@ describe.only("Tests for Deposit", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Bsc/11_DexRepayment.test.ts
+++ b/test/Bsc/11_DexRepayment.test.ts
@@ -391,7 +391,7 @@ describe.only("Tests for Deposit", () => {
             _feeModuleImplementationAddress: feeModule.address,
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _baseBorrowManager: borrowManager.address,
             _gnosisSingleton: addresses.gnosisSingleton,
@@ -1682,9 +1682,9 @@ describe.only("Tests for Deposit", () => {
 
         const flashLoanAmount = values[1];
 
-        await portfolio.connect(nonOwner).multiTokenWithdrawal(
-          BigNumber.from(amountPortfolioToken),
-          {
+        await portfolio
+          .connect(nonOwner)
+          .multiTokenWithdrawal(BigNumber.from(amountPortfolioToken), {
             _factory: addresses.thena_factory,
             _token0: addresses.USDT, //USDT - Pool token
             _token1: addresses.USDC_Address, //USDC - Pool token
@@ -1697,8 +1697,7 @@ describe.only("Tests for Deposit", () => {
             isDexRepayment: true,
             _poolFees: [[500, 500, 500, 500, 500, 500, 500, 500, 500]],
             _swapHandler: swapHandler.address,
-          }
-        );
+          });
 
         const supplyAfter = await portfolio.totalSupply();
         console.log("SupplyAfter", supplyAfter);

--- a/test/Bsc/12_AlgebraV2_1.test.ts
+++ b/test/Bsc/12_AlgebraV2_1.test.ts
@@ -350,7 +350,7 @@ describe.only("Tests for Deposit", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,
@@ -467,7 +467,7 @@ describe.only("Tests for Deposit", () => {
         thenaProtocolHash,
         "0xbf77b742eE1c0a6883c009Ce590A832DeBe74064",
         "0x76689a9Be4759F9cEcb5a1d86d4f371b6DB4C7a6",
-        positionWrapperBaseAddress.address
+        positionManagerBaseAddress.address
       );
 
       await assetManagementConfig.enableUniSwapV3Manager(thenaProtocolHash);
@@ -1028,10 +1028,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1148,10 +1149,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1270,10 +1272,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];

--- a/test/Bsc/13_Algebrav2_1Bundle.test.ts
+++ b/test/Bsc/13_Algebrav2_1Bundle.test.ts
@@ -352,7 +352,7 @@ describe.only("Tests for Deposit", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,
@@ -467,7 +467,7 @@ describe.only("Tests for Deposit", () => {
         thenaProtocolHash,
         "0xbf77b742eE1c0a6883c009Ce590A832DeBe74064",
         "0x76689a9Be4759F9cEcb5a1d86d4f371b6DB4C7a6",
-        positionWrapperBaseAddress.address
+        positionManagerBaseAddress.address
       );
 
       await assetManagementConfig.enableUniSwapV3Manager(thenaProtocolHash);

--- a/test/Bsc/1_IndexConfig.test.ts
+++ b/test/Bsc/1_IndexConfig.test.ts
@@ -142,13 +142,6 @@ describe.only("Tests for Portfolio Config", () => {
       protocolConfig = ProtocolConfig.attach(_protocolConfig.address);
       await protocolConfig.setCoolDownPeriod("70");
 
-      await protocolConfig.enableProtocol(
-        thenaProtocolHash,
-        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
-        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
-        positionWrapperBaseAddress.address
-      );
-
       const Rebalancing = await ethers.getContractFactory("Rebalancing");
       const rebalancingDefult = await Rebalancing.deploy();
       await rebalancingDefult.deployed();
@@ -219,6 +212,13 @@ describe.only("Tests for Portfolio Config", () => {
       const positionManagerBaseAddress = await PositionManager.deploy();
       await positionManagerBaseAddress.deployed();
 
+      await protocolConfig.enableProtocol(
+        thenaProtocolHash,
+        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
+        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
+        positionManagerBaseAddress.address
+      );
+
       const FeeModule = await ethers.getContractFactory("FeeModule", {});
       const feeModule = await FeeModule.deploy();
       await feeModule.deployed();
@@ -265,7 +265,7 @@ describe.only("Tests for Portfolio Config", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,
@@ -1950,7 +1950,7 @@ describe.only("Tests for Portfolio Config", () => {
       it("should fail if repay is paused", async () => {
         await protocolConfig.setRepayPause(true);
         await expect(
-           rebalancing.repay(addresses.corePool_controller, {
+          rebalancing.repay(addresses.corePool_controller, {
             _factory: addresses.thena_factory,
             _token0: addresses.USDT, //USDT - Pool token
             _token1: addresses.USDC_Address, //USDC - Pool token

--- a/test/Bsc/2_Upgradeability.test.ts
+++ b/test/Bsc/2_Upgradeability.test.ts
@@ -151,7 +151,9 @@ describe.only("Tests for Upgradeability", () => {
       const assetManagementConfig = await AssetManagementConfig.deploy();
       await assetManagementConfig.deployed();
 
-      const BorrowManager = await ethers.getContractFactory("BorrowManagerVenus");
+      const BorrowManager = await ethers.getContractFactory(
+        "BorrowManagerVenus"
+      );
       borrowManager = await BorrowManager.deploy();
       await borrowManager.deployed();
 
@@ -269,7 +271,7 @@ describe.only("Tests for Upgradeability", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,
@@ -512,10 +514,11 @@ describe.only("Tests for Upgradeability", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -912,10 +915,11 @@ describe.only("Tests for Upgradeability", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1306,10 +1310,11 @@ describe.only("Tests for Upgradeability", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1690,10 +1695,11 @@ describe.only("Tests for Upgradeability", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];

--- a/test/Bsc/3_Withdrawal.test.ts
+++ b/test/Bsc/3_Withdrawal.test.ts
@@ -160,7 +160,9 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       const tokenExclusionManagerDefault = await TokenExclusionManager.deploy();
       await tokenExclusionManagerDefault.deployed();
 
-      const BorrowManager = await ethers.getContractFactory("BorrowManagerVenus");
+      const BorrowManager = await ethers.getContractFactory(
+        "BorrowManagerVenus"
+      );
       borrowManager = await BorrowManager.deploy();
       await borrowManager.deployed();
 
@@ -268,7 +270,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,
@@ -574,10 +576,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -650,10 +653,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -787,10 +791,11 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1133,7 +1138,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             secondSwapData: [["0x"]],
             isDexRepayment: false,
             _poolFees: [[0, 0, 0]],
-            _swapHandler: swapHandler.address, 
+            _swapHandler: swapHandler.address,
           });
 
         const supplyAfter = await portfolio.totalSupply();

--- a/test/Bsc/4_Deposit.test.ts
+++ b/test/Bsc/4_Deposit.test.ts
@@ -258,7 +258,7 @@ describe.only("Tests for Deposit", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Bsc/5_BatchTx.test.ts
+++ b/test/Bsc/5_BatchTx.test.ts
@@ -181,7 +181,9 @@ describe.only("Tests for Deposit", () => {
       const assetManagementConfig = await AssetManagementConfig.deploy();
       await assetManagementConfig.deployed();
 
-      const BorrowManager = await ethers.getContractFactory("BorrowManagerVenus");
+      const BorrowManager = await ethers.getContractFactory(
+        "BorrowManagerVenus"
+      );
       borrowManager = await BorrowManager.deploy();
       await borrowManager.deployed();
 
@@ -288,7 +290,7 @@ describe.only("Tests for Deposit", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Bsc/6_PositionWrapperBundle.test.ts
+++ b/test/Bsc/6_PositionWrapperBundle.test.ts
@@ -240,13 +240,6 @@ describe.only("Tests for Deposit", () => {
         iaddress.usdtAddress,
       ]);
 
-      await protocolConfig.enableProtocol(
-        thenaProtocolHash,
-        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
-        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
-        positionWrapperBaseAddress.address
-      );
-
       const Rebalancing = await ethers.getContractFactory("Rebalancing");
       const rebalancingDefult = await Rebalancing.deploy();
       await rebalancingDefult.deployed();
@@ -309,6 +302,13 @@ describe.only("Tests for Deposit", () => {
       const positionManagerBaseAddress = await PositionManager.deploy();
       await positionManagerBaseAddress.deployed();
 
+      await protocolConfig.enableProtocol(
+        thenaProtocolHash,
+        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
+        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
+        positionManagerBaseAddress.address
+      );
+
       const AmountCalculationsAlgebra = await ethers.getContractFactory(
         "AmountCalculationsAlgebra"
       );
@@ -358,7 +358,7 @@ describe.only("Tests for Deposit", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/Bsc/7_PositionWrapper.test.ts
+++ b/test/Bsc/7_PositionWrapper.test.ts
@@ -108,6 +108,8 @@ describe.only("Tests for Deposit", () => {
   let feeModule0: FeeModule;
   let zeroAddress: any;
   let assetManagementConfig1: AssetManagementConfig;
+  let positionManagerBaseAddress: any;
+
   const assetManagerHash = ethers.utils.keccak256(
     ethers.utils.toUtf8Bytes("ASSET_MANAGER")
   );
@@ -230,13 +232,6 @@ describe.only("Tests for Deposit", () => {
       await protocolConfig.setCoolDownPeriod("70");
       await protocolConfig.enableSolverHandler(ensoHandler.address);
 
-      await protocolConfig.enableProtocol(
-        thenaProtocolHash,
-        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
-        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
-        positionWrapperBaseAddress.address
-      );
-
       const Rebalancing = await ethers.getContractFactory("Rebalancing");
       const rebalancingDefult = await Rebalancing.deploy();
       await rebalancingDefult.deployed();
@@ -297,8 +292,15 @@ describe.only("Tests for Deposit", () => {
           },
         }
       );
-      const positionManagerBaseAddress = await PositionManager.deploy();
+      positionManagerBaseAddress = await PositionManager.deploy();
       await positionManagerBaseAddress.deployed();
+
+      await protocolConfig.enableProtocol(
+        thenaProtocolHash,
+        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
+        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
+        positionManagerBaseAddress.address
+      );
 
       const AmountCalculationsAlgebra = await ethers.getContractFactory(
         "AmountCalculationsAlgebra"
@@ -349,7 +351,7 @@ describe.only("Tests for Deposit", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,
@@ -503,7 +505,7 @@ describe.only("Tests for Deposit", () => {
           thenaProtocolHash2,
           "0xa51adb08cbe6ae398046a23bec013979816b77ab",
           "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
-          positionWrapperBaseAddress.address
+          positionManagerBaseAddress.address
         );
         await expect(
           assetManagementConfig1
@@ -1031,10 +1033,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1145,10 +1148,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1267,10 +1271,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];

--- a/test/Bsc/8_PositionWrapperOneSided.test.ts
+++ b/test/Bsc/8_PositionWrapperOneSided.test.ts
@@ -228,13 +228,6 @@ describe.only("Tests for Deposit", () => {
         iaddress.usdtAddress,
       ]);
 
-      await protocolConfig.enableProtocol(
-        thenaProtocolHash,
-        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
-        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
-        positionWrapperBaseAddress.address
-      );
-
       const Rebalancing = await ethers.getContractFactory("Rebalancing");
       const rebalancingDefult = await Rebalancing.deploy();
       await rebalancingDefult.deployed();
@@ -352,6 +345,13 @@ describe.only("Tests for Deposit", () => {
       const positionManagerBaseAddress = await PositionManager.deploy();
       await positionManagerBaseAddress.deployed();
 
+      await protocolConfig.enableProtocol(
+        thenaProtocolHash,
+        "0xa51adb08cbe6ae398046a23bec013979816b77ab",
+        "0x327dd3208f0bcf590a66110acb6e5e6941a4efa0",
+        positionManagerBaseAddress.address
+      );
+
       const AmountCalculationsAlgebra = await ethers.getContractFactory(
         "AmountCalculationsAlgebra"
       );
@@ -400,7 +400,7 @@ describe.only("Tests for Deposit", () => {
             _feeModuleImplementationAddress: feeModule.address,
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _baseBorrowManager: borrowManager.address,
             _gnosisSingleton: addresses.gnosisSingleton,
@@ -784,10 +784,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -898,10 +899,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await owner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];
@@ -1020,10 +1022,11 @@ describe.only("Tests for Deposit", () => {
         const signature = await nonOwner._signTypedData(domain, types, values);
 
         // Calculation to make minimum amount value for user---------------------------------
-        let result = await portfolioCalculations.callStatic.getUserAmountToDeposit(
-          amounts,
-          portfolio.address
-        );
+        let result =
+          await portfolioCalculations.callStatic.getUserAmountToDeposit(
+            amounts,
+            portfolio.address
+          );
         //-----------------------------------------------------------------------------------
 
         newAmounts = result[0];

--- a/test/Bsc/9_Borrowing.test.ts
+++ b/test/Bsc/9_Borrowing.test.ts
@@ -391,7 +391,7 @@ describe.only("Tests for Deposit", () => {
             _feeModuleImplementationAddress: feeModule.address,
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _baseBorrowManager: borrowManager.address,
             _gnosisSingleton: addresses.gnosisSingleton,

--- a/test/base/1_MetaAggregatorTest.test.ts
+++ b/test/base/1_MetaAggregatorTest.test.ts
@@ -265,7 +265,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/base/2_EnsoTest.test.ts
+++ b/test/base/2_EnsoTest.test.ts
@@ -266,7 +266,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/base/3_MetaEnsoTest.test.ts
+++ b/test/base/3_MetaEnsoTest.test.ts
@@ -265,7 +265,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _baseTokenRemovalVaultImplementation: tokenRemovalVault.address,
             _baseVelvetGnosisSafeModuleAddress: velvetSafeModule.address,
             _baseBorrowManager: borrowManager.address,
-            _basePositionManager: positionManagerBaseAddress.address,
+            _basePositionWrapper: positionWrapperBaseAddress.address,
             _baseExternalPositionStorage: externalPositionStorage.address,
             _gnosisSingleton: addresses.gnosisSingleton,
             _gnosisFallbackLibrary: addresses.gnosisFallbackLibrary,

--- a/test/foundry/utils/PortfolioDeployment.s.sol
+++ b/test/foundry/utils/PortfolioDeployment.s.sol
@@ -50,7 +50,7 @@ contract PortfolioDeployment is Script, Addresses {
           _baseTokenRemovalVaultImplementation: tokenRemovalVault,
           _baseVelvetGnosisSafeModuleAddress: safe,
           _gnosisSingleton: BSC_GNOSIS_SINGLETON,
-          _basePositionManager: address(0), // @todo add base implementation
+          _basePositionWrapper: address(0), // @todo add base implementation
           _baseExternalPositionStorage: address(0), // @todo add base implementation
           _baseBorrowManager: address(0), // @todo add base implementation
           _gnosisFallbackLibrary: BSC_GNOSIS_FALLBACK_LIB,


### PR DESCRIPTION
Previously, we were incorrectly setting the position wrapper address for 
each position ID. This approach was flawed because:

- The position wrapper is a reusable contract implementation that should 
  be shared across all positions
- We were unnecessarily duplicating the same contract for each position ID
- The architecture mixed concerns between position wrappers and position 
  managers

**Solution:**
- Position Wrapper: Now uses a single, shared base implementation 
  (basePositionWrapper) that can be reused across all positions
- Position Manager: Made protocol-specific and passed when enabling new 
  protocols via ProtocolConfig.enableProtocol()
- Clear Separation: Position wrappers handle individual position logic, 
  while position managers handle protocol-specific operations

**Changes:**
- Added basePositionWrapper() getter function to ExternalPositionManagement
- Updated protocol enablement to accept protocol-specific position manager 
  implementations
- Fixed contract architecture to properly separate reusable components 
  from protocol-specific ones
