### PR TITLE
fix:flashloan fee adjustment for thena

### DIFF
--- a/contracts/front-end-helpers/PortfolioCalculations.sol
+++ b/contracts/front-end-helpers/PortfolioCalculations.sol
@@ -657,6 +657,15 @@ contract PortfolioCalculations is ExponentialNoError {
     return IThena(_pool).globalState().lastFee;
   }
 
+  function getFlashLoanFeeFromPool(
+    address _factory,
+    address _token0,
+    address _token1
+  ) external view returns (uint256) {
+    address poolAddress = IThena(_factory).poolByPair(_token0, _token1);
+    return IThena(poolAddress).globalState().lastFee;
+  }
+
   function getCollateralAmountToSell(
     address _user,
     address _controller,
@@ -730,7 +739,7 @@ contract PortfolioCalculations is ExponentialNoError {
     uint256 borrowBalance,
     uint256 totalCollateral
   ) internal pure returns (uint256 debtValue, uint256 percentageToRemove) {
-    uint256 feeAmount = (_debtRepayAmount * 10 ** 18 * feeUnit) / 10 ** 22;
+    uint256 feeAmount = (_debtRepayAmount * 10 ** 18 * feeUnit) / 10 ** 24;
     uint256 debtAmountWithFee = _debtRepayAmount + feeAmount;
     debtValue = (debtAmountWithFee * totalDebt * 10 ** 18) / borrowBalance;
     percentageToRemove = debtValue / totalCollateral;

--- a/contracts/handler/Venus/VenusAssetHandler.sol
+++ b/contracts/handler/Venus/VenusAssetHandler.sol
@@ -731,7 +731,7 @@ contract VenusAssetHandler is IAssetHandler, ExponentialNoError {
     uint256 borrowBalance,
     uint256 totalCollateral
   ) internal pure returns (uint256 debtValue, uint256 percentageToRemove) {
-    uint256 feeAmount = (_debtRepayAmount * 10 ** 18 * feeUnit) / 10 ** 22; // Calculate the fee amount
+    uint256 feeAmount = (_debtRepayAmount * 10 ** 18 * feeUnit) / 10 ** 24; // Calculate the fee amount
     uint256 debtAmountWithFee = _debtRepayAmount + feeAmount; // Add the fee to the debt repayment amount
     debtValue = (debtAmountWithFee * totalDebt * 10 ** 18) / borrowBalance; // Calculate the debt value
     percentageToRemove = debtValue / totalCollateral; // Calculate the percentage to remove from collateral

--- a/test/Bsc/10_Stratergy.test.ts
+++ b/test/Bsc/10_Stratergy.test.ts
@@ -1284,7 +1284,7 @@ describe.only("Tests for Deposit", () => {
         let tokens = await portfolio.getTokens();
 
         let flashloanBufferUnit = 23; //Flashloan buffer unit in 1/10000
-        let bufferUnit = 160; //Buffer unit for collateral amount in 1/100000
+        let bufferUnit = 300; //Buffer unit for collateral amount in 1/100000
 
         let balanceBorrowed =
           await portfolioCalculations.getVenusTokenBorrowedBalance(
@@ -1329,6 +1329,13 @@ describe.only("Tests for Deposit", () => {
         );
 
         let encodedParameters1 = [];
+
+        const flashLoanFee = await portfolioCalculations.getFlashLoanFeeFromPool(
+          addresses.thena_factory,
+          addresses.USDT, //USDT - Pool token
+          addresses.USDC_Address //USDC - Pool token
+        );
+
         //Because repay(rebalance) is one borrow token at a time
         const amounToSell =
           await portfolioCalculations.callStatic.getCollateralAmountToSell(
@@ -1338,7 +1345,7 @@ describe.only("Tests for Deposit", () => {
             [addresses.vDAI_Address],
             tokens,
             [balanceToRepay],
-            "10", //Flash loan fee
+            flashLoanFee, //Flash loan fee
             bufferUnit //Buffer unit for collateral amount
           );
         console.log("amounToSell", amounToSell);

--- a/test/Bsc/11_DexRepayment.test.ts
+++ b/test/Bsc/11_DexRepayment.test.ts
@@ -305,6 +305,8 @@ describe.only("Tests for Deposit", () => {
 
       await protocolConfig.setSupportedFactory(addresses.thena_factory);
 
+      await protocolConfig.updateMaxCollateralBufferUnit(800);
+
       await protocolConfig.setAssetAndMarketControllers(
         [
           addresses.vBNB_Address,
@@ -1008,8 +1010,8 @@ describe.only("Tests for Deposit", () => {
         let ERC20 = await ethers.getContractFactory("ERC20Upgradeable");
         let tokens = await portfolio.getTokens();
 
-        let flashloanBufferUnit = 31; //Flashloan buffer unit in 1/10000
-        let bufferUnit = 350; //Buffer unit for collateral amount in 1/100000
+        let flashloanBufferUnit = 20; //Flashloan buffer unit in 1/10000
+        let bufferUnit = 600; //Buffer unit for collateral amount in 1/100000
         let borrowedToken = addresses.BTC_Address;
         let borrowedProtocolToken = addresses.vBTC_Address;
 
@@ -1043,6 +1045,14 @@ describe.only("Tests for Deposit", () => {
         console.log("balanceToRepay", balanceToRepay);
         console.log("balanceToSwap", balanceToSwap);
 
+        const flashLoanFee = await portfolioCalculations.getFlashLoanFeeFromPool(
+          addresses.thena_factory,
+          addresses.USDT, //USDT - Pool token
+          addresses.USDC_Address //USDC - Pool token
+        );
+
+        console.log("flashLoanFee", flashLoanFee);
+
         //Because repay(rebalance) is one borrow token at a time
         const amounToSell =
           await portfolioCalculations.callStatic.getCollateralAmountToSell(
@@ -1052,7 +1062,7 @@ describe.only("Tests for Deposit", () => {
             [borrowedProtocolToken],
             tokens,
             [balanceToRepay],
-            "10", //Flash loan fee
+            flashLoanFee, //Flash loan fee
             bufferUnit //Buffer unit for collateral amount
           );
         console.log("amounToSell", amounToSell);

--- a/test/Bsc/9_Borrowing.test.ts
+++ b/test/Bsc/9_Borrowing.test.ts
@@ -305,6 +305,8 @@ describe.only("Tests for Deposit", () => {
 
       await protocolConfig.setSupportedFactory(addresses.thena_factory);
 
+      protocolConfig.updateMaxCollateralBufferUnit(800);
+
       await protocolConfig.setAssetAndMarketControllers(
         [
           addresses.vBNB_Address,
@@ -1008,8 +1010,8 @@ describe.only("Tests for Deposit", () => {
         let ERC20 = await ethers.getContractFactory("ERC20Upgradeable");
         let tokens = await portfolio.getTokens();
 
-        let flashloanBufferUnit = 38; //Flashloan buffer unit in 1/10000
-        let bufferUnit = 363; //Buffer unit for collateral amount in 1/100000
+        let flashloanBufferUnit = 20; //Flashloan buffer unit in 1/10000
+        let bufferUnit = 600; //Buffer unit for collateral amount in 1/100000
         let borrowedToken = addresses.BTC_Address;
         let borrowedProtocolToken = addresses.vBTC_Address;
 
@@ -1055,6 +1057,14 @@ describe.only("Tests for Deposit", () => {
           [[postResponse.data.tx.data], [borrowedToken], [0]]
         );
 
+        const flashLoanFee = await portfolioCalculations.getFlashLoanFeeFromPool(
+          addresses.thena_factory,
+          addresses.USDT, //USDT - Pool token
+          addresses.USDC_Address //USDC - Pool token
+        );
+
+        console.log("flashLoanFee", flashLoanFee);
+
         let encodedParameters1 = [];
         //Because repay(rebalance) is one borrow token at a time
         const amounToSell =
@@ -1065,7 +1075,7 @@ describe.only("Tests for Deposit", () => {
             [borrowedProtocolToken],
             tokens,
             [balanceToRepay],
-            "10", //Flash loan fee
+            flashLoanFee, //Flash loan fee
             bufferUnit //Buffer unit for collateral amount
           );
         console.log("amounToSell", amounToSell);
@@ -1493,8 +1503,8 @@ describe.only("Tests for Deposit", () => {
         let ERC20 = await ethers.getContractFactory("ERC20Upgradeable");
         let tokens = await portfolio.getTokens();
 
-        let flashloanBufferUnit = 30; //Flashloan buffer unit in 1/10000
-        let bufferUnit = 320; //Buffer unit for collateral amount in 1/100000
+        let flashloanBufferUnit = 20; //Flashloan buffer unit in 1/10000
+        let bufferUnit = 600; //Buffer unit for collateral amount in 1/100000
 
         let balanceBorrowed =
           await portfolioCalculations.getVenusTokenBorrowedBalance(
@@ -1540,6 +1550,13 @@ describe.only("Tests for Deposit", () => {
 
         let encodedParameters1 = [];
         //Because repay(rebalance) is one borrow token at a time
+        // Get flash loan fee from Thena pool
+        const flashLoanFee = await portfolioCalculations.getFlashLoanFeeFromPool(
+          addresses.thena_factory,
+          addresses.USDT, //USDT - Pool token
+          addresses.USDC_Address //USDC - Pool token
+        );
+
         const amounToSell =
           await portfolioCalculations.callStatic.getCollateralAmountToSell(
             vault,
@@ -1548,7 +1565,7 @@ describe.only("Tests for Deposit", () => {
             [addresses.vDAI_Address],
             tokens,
             [balanceToRepay],
-            "10", //Flash loan fee
+            flashLoanFee, //Flash loan fee from pool
             bufferUnit //Buffer unit for collateral amount
           );
         console.log("amounToSell", amounToSell);
@@ -1617,8 +1634,8 @@ describe.only("Tests for Deposit", () => {
 
         let vault = await portfolio.vault();
 
-        let flashloanBufferUnit = 11; //Flashloan buffer unit in 1/10000
-        let bufferUnit = 300; //Buffer unit for collateral amount in 1/100000
+        let flashloanBufferUnit = 15; //Flashloan buffer unit in 1/10000
+        let bufferUnit = 400; //Buffer unit for collateral amount in 1/100000
 
         let flashLoanToken = addresses.USDT;
         let flashLoanProtocolToken = addresses.vUSDT_Address;
@@ -1728,6 +1745,12 @@ describe.only("Tests for Deposit", () => {
           }
         }
 
+        const flashLoanFee = await portfolioCalculations.getFlashLoanFeeFromPool(
+          addresses.thena_factory,
+          addresses.USDT, //USDT - Pool token
+          addresses.USDC_Address //USDC - Pool token
+        );
+
         const amounToSell =
           await portfolioCalculations.callStatic.getCollateralAmountToSell(
             vault,
@@ -1736,7 +1759,7 @@ describe.only("Tests for Deposit", () => {
             borrowedTokens,
             tokens,
             borrowedPortion,
-            "10", //Flash loan fee
+            flashLoanFee, //Flash loan fee
             bufferUnit //Buffer unit for collateral amount
           );
 
@@ -1808,7 +1831,7 @@ describe.only("Tests for Deposit", () => {
         const user = nonOwner;
 
         let flashloanBufferUnit = 11; //Flashloan buffer unit in 1/10000.This value is used slightly increase the amount of flashLoanAmount, for any priceImpact (10000 = 100%)
-        let bufferUnit = 300; //The buffer unit used to slightly increase the amount of collateral to sell, expressed in 0.001% (100000 = 100%)
+        let bufferUnit = 350; //The buffer unit used to slightly increase the amount of collateral to sell, expressed in 0.001% (100000 = 100%)
 
         const ERC20 = await ethers.getContractFactory("ERC20Upgradeable");
         const tokens = await portfolio.getTokens();
@@ -1925,6 +1948,12 @@ describe.only("Tests for Deposit", () => {
           }
         }
 
+        const flashLoanFee = await portfolioCalculations.getFlashLoanFeeFromPool(
+          addresses.thena_factory,
+          addresses.USDT, //USDT - Pool token
+          addresses.USDC_Address //USDC - Pool token
+        );
+
         const amounToSell =
           await portfolioCalculations.callStatic.getCollateralAmountToSell(
             vault,
@@ -1933,7 +1962,7 @@ describe.only("Tests for Deposit", () => {
             borrowedTokens,
             tokens,
             borrowedPortion,
-            "10", //Flash loan fee
+            flashLoanFee, //Flash loan fee
             bufferUnit //Buffer unit for collateral amount
           );
 


### PR DESCRIPTION

## Description

**Fix: Update flash loan fee calculation in `getCollateralAmountToSell`**

- **Issue**: Flash loan fee calculation was using incorrect divisor (`10**22` instead of `10**24`)
- **Root Cause**: Thena flash loan fees are in 1,000,000 basis (6 decimals), requiring `10**24` divisor for proper calculation
- **Fix**: Updated fee calculation in `calculateDebtAndPercentage` function to use `10**24` divisor
- **Impact**: Ensures accurate collateral amount calculations when repaying borrowed tokens using flash loans

**Changes:**
- Modified `calculateDebtAndPercentage` in `PortfolioCalculations.sol` to use correct divisor
- Updated test file to use dynamic flash loan fees from Thena pool instead of hardcoded values
- Added `getFlashLoanFeeFromPool` function to fetch real-time fees from pool's `globalstate.lastFee`