### PR TITLE
Fix:borrowManager fund stuck issue

### DIFF
--- a/contracts/core/management/BorrowManager/AbstractBorrowManager.sol
+++ b/contracts/core/management/BorrowManager/AbstractBorrowManager.sol
@@ -121,6 +121,13 @@ abstract contract AbstractBorrowManager is
       // Check if the delegatecall was successful
       // If not, revert the transaction with a custom error
       if (!success) revert ErrorLibrary.RepayBorrowCallFailed();
+
+      // Transfer any remaining dust balance back to the vault
+      TransferHelper.safeTransfer(
+        repayData._flashLoanToken,
+        _vault,
+        IERC20Upgradeable(repayData._flashLoanToken).balanceOf(address(this))
+      );
     }
   }
 

--- a/test/Bsc/11_DexRepayment.test.ts
+++ b/test/Bsc/11_DexRepayment.test.ts
@@ -36,6 +36,7 @@ import {
   VenusAssetHandler,
   IAssetHandler,
   IVenusComptroller,
+  BorrowManagerVenus__factory,
 } from "../../typechain";
 
 import { chainIdToAddresses } from "../../scripts/networkVariables";
@@ -57,6 +58,7 @@ describe.only("Tests for Deposit", () => {
   let tokenExclusionManager: any;
   let tokenExclusionManager1: any;
   let borrowManager: BorrowManagerVenus;
+  let borrowManagerVenus: any;
   let ensoHandler: EnsoHandler;
   let depositBatch: DepositBatch;
   let depositManager: DepositManager;
@@ -456,6 +458,13 @@ describe.only("Tests for Deposit", () => {
         });
       const portfolioAddress = await portfolioFactory.getPortfolioList(0);
       const portfolioInfo = await portfolioFactory.PortfolioInfolList(0);
+
+      const borrowManagerVenusAddress = await portfolioInfo.borrowManager;
+      borrowManagerVenus = await ethers.getContractAt(
+        BorrowManagerVenus__factory.abi,
+        borrowManagerVenusAddress
+      );
+
 
       const portfolioAddress1 = await portfolioFactory.getPortfolioList(1);
       const portfolioInfo1 = await portfolioFactory.PortfolioInfolList(1);
@@ -1618,9 +1627,10 @@ describe.only("Tests for Deposit", () => {
           },
           responses
         );
-
         const supplyAfter = await portfolio.totalSupply();
         console.log("SupplyAfter", supplyAfter);
+
+        expect(await ERC20.attach(flashLoanToken).balanceOf(borrowManagerVenus.address)).to.be.equal(0);
 
         for (let i = 0; i < tokens.length; i++) {
           let balanceAfter = await ERC20.attach(tokens[i]).balanceOf(
@@ -1712,6 +1722,8 @@ describe.only("Tests for Deposit", () => {
         const supplyAfter = await portfolio.totalSupply();
         console.log("SupplyAfter", supplyAfter);
 
+        expect(await ERC20.attach(flashLoanToken).balanceOf(borrowManagerVenus.address)).to.be.equal(0);
+        
         for (let i = 0; i < tokens.length; i++) {
           let balanceAfter = await ERC20.attach(tokens[i]).balanceOf(
             user.address


### PR DESCRIPTION
## 🐛 Fix: Transfer Flash Loan Tokens to Vault During Withdrawal

### Problem
Flash loan tokens were getting stuck in the `BorrowManager` contract during user withdrawals, even after debt repayment was completed.

### Root Cause
While the asset manager properly handled flash loan token transfers during debt repayment, the user withdrawal flow was missing this critical step.

### Solution
Added flash loan token transfer to vault during withdrawal and after debt repayment to ensure funds don't remain locked in the `BorrowManager` contract.

### Changes Made
- Added flash loan token transfer logic during withdrawal process
