### PR TITLE
fix:assetHandler collateral issue

### DIFF
--- a/contracts/handler/Aave/AaveAssetHandler.sol
+++ b/contracts/handler/Aave/AaveAssetHandler.sol
@@ -1053,6 +1053,16 @@ contract AaveAssetHandler is IAssetHandler {
           )
         });
         feeCount++;
+      }else{
+        transactions[count++] = MultiTransaction({
+          to: _context.executor,
+          txData: abi.encodeWithSelector(
+            bytes4(keccak256("vaultInteraction(address,uint256,bytes)")),
+            underlying,
+            0,
+            abi.encodeWithSelector(bytes4(keccak256("transfer(address,uint256)")), _context.receiver, _sellAmount)
+          )
+        });
       }
       unchecked {
         ++j;

--- a/contracts/handler/Venus/VenusAssetHandler.sol
+++ b/contracts/handler/Venus/VenusAssetHandler.sol
@@ -1435,6 +1435,15 @@ contract VenusAssetHandler is IAssetHandler, ExponentialNoError {
         );
         count++;
         feeCount++;
+      }else{
+        transactions[count].to = _context.executor;
+        transactions[count].txData = abi.encodeWithSelector(
+          bytes4(keccak256("vaultInteraction(address,uint256,bytes)")),
+          underlying,
+          0,
+          abi.encodeWithSelector(bytes4(keccak256("transfer(address,uint256)")), _context.receiver, underlyingAmount)
+        );
+        count++;
       }
 
       unchecked {


### PR DESCRIPTION
Fixed assetHandler: If collateral token underlying == flashLoanToken, the redeemed token was left in vault and not in borrowManager Venus